### PR TITLE
Remove colons from the datestring to have logdir

### DIFF
--- a/train.py
+++ b/train.py
@@ -86,7 +86,7 @@ def create_vctk_inputs(directory, sample_rate=16000):
 
 def main():
     args = get_arguments()
-    datestring = str(datetime.now()).replace(' ', 'T')
+    datestring = "{0:%Y-%m-%dT%H-%M-%S}".format(datetime.now())
     logdir = os.path.join(args.logdir, 'train', datestring)
 
     with open(args.wavenet_params, 'r') as f:


### PR DESCRIPTION
It is to avoid the path issue as follows on restoring checkpoint later.

```
tensorflow.python.framework.errors.UnimplementedError: File system scheme `{{ incomplete_path }}` not implemented
```

where `{{ incomplete_path }}` is like: `logdir/train/2016-09-18T01` (terminated before the colon).