### PR TITLE
Add net training test.

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -9,6 +9,7 @@ conda update -q conda
 conda create -q -n test python=$TRAVIS_PYTHON_VERSION numpy scipy
 source activate test
 pip install nose
+pip install librosa
 
 pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-$TENSORFLOW-cp35-cp35m-linux_x86_64.whl
 

--- a/test/test_net.py
+++ b/test/test_net.py
@@ -14,8 +14,8 @@ def MakeSineWaves():
     p1 = 1.0/155.56 # E-flat
     p2 = 1.0/196.00 # G
     p3 = 1.0/233.08 # B-flat
-    # One quarter-second of data.
-    times = np.arange(0.0, 0.25, sample_rate)
+    # 100 mSec of data.
+    times = np.arange(0.0, 0.10, sample_rate)
 
     # Amplitudes
     amplitudes = np.sin(times*2.0*np.pi/p1)/3.0 +  \
@@ -46,8 +46,6 @@ class TestNet(tf.test.TestCase):
     def testEndToEndTraining(self):
         audio = MakeSineWaves()
         np.random.seed(42)
-
-        print "lr:", self.args.learning_rate
 
         audio_tensor = tf.convert_to_tensor(audio, dtype=tf.float32)
         loss = self.net.loss(audio_tensor)

--- a/test/test_net.py
+++ b/test/test_net.py
@@ -1,0 +1,80 @@
+
+import tensorflow as tf
+import numpy as np
+from wavenet_ops import time_to_batch, batch_to_time, causal_conv
+from train import WaveNet, get_arguments
+import json
+
+
+# Create a time-series of audio amplitudes corresponding to 3 superimposed
+# sine waves.
+def MakeSineWaves():
+    sample_rate = 1.0/16000.0
+    # Period of the sine wave is inverse of frequency in hz.
+    p1 = 1.0/155.56 # E-flat
+    p2 = 1.0/196.00 # G
+    p3 = 1.0/233.08 # B-flat
+    # One quarter-second of data.
+    times = np.arange(0.0, 0.25, sample_rate)
+
+    # Amplitudes
+    amplitudes = np.sin(times*2.0*np.pi/p1)/3.0 +  \
+                 np.sin(times*2.0*np.pi/p2)/3.0 +  \
+                 np.sin(times*2.0*np.pi/p3)/3.0
+
+    return amplitudes
+
+
+class TestNet(tf.test.TestCase):
+    def setUp(self):
+        self.args = get_arguments()
+
+        with open(self.args.wavenet_params, 'r') as f:
+            wavenet_params = json.load(f)
+
+        self.net = WaveNet(self.args.batch_size,
+                           wavenet_params["quantization_steps"],
+                           wavenet_params["dilations"],
+                           wavenet_params["filter_width"],
+                           wavenet_params["residual_channels"],
+                           wavenet_params["dilation_channels"])
+
+    # Train a net on a short clip of 3 sine waves superimposed (an e-flat chord)
+    # Presumably it can overfit to such a simple signal. This test serves
+    # as a smoke test where we just check that it runs end-to-end during
+    # training, and learns this waveform.
+    def testEndToEndTraining(self):
+        audio = MakeSineWaves()
+        np.random.seed(42)
+
+        print "lr:", self.args.learning_rate
+
+        audio_tensor = tf.convert_to_tensor(audio, dtype=tf.float32)
+        loss = self.net.loss(audio_tensor)
+        optimizer = tf.train.AdamOptimizer(learning_rate=self.args.learning_rate)
+        trainable = tf.trainable_variables()
+        optim = optimizer.minimize(loss, var_list=trainable)
+        init = tf.initialize_all_variables()
+
+        max_allowed_loss = 0.1
+        loss_val = max_allowed_loss
+        initial_loss = None
+        with self.test_session() as sess:
+            sess.run(init)
+            initial_loss = sess.run(loss)
+            for i in range(50):
+                loss_val, _ = sess.run([loss, optim])
+                #print "i: %d loss: %f" % (i, loss_val)
+
+        # Sanity check the initial loss was larger.
+        self.assertGreater(initial_loss, max_allowed_loss)
+
+        # Loss after training should be small.
+        self.assertLess(loss_val, max_allowed_loss)
+
+        # Loss should be at least two orders of magnitude better
+        # than before training.
+        self.assertLess(loss_val/initial_loss, 0.01)
+
+if __name__ == '__main__':
+    tf.test.main()


### PR DESCRIPTION
Pertaining to [issue 24](https://github.com/ibab/tensorflow-wavenet/issues/24), this adds a test that trains the network to learn a simple audio clip (3 tones forming a chord, at least that's what it is supposed to be). The idea is to provide broad coverage of the code and sanity check that the WaveNet is trainable. 

It runs in a couple seconds of seconds on my machine, but might not be Travis-friendly since I think it has to run on the CPU there. 

If you uncomment the print statement you can see the loss drops very close to zero, so it has successfully overfit to the 0.10 second long clip.

It would be interesting to save the generated audio (and training audio) out to .wav file to see how well it sounds.

Edit: build fails at moment because travis can't find librosa. 
