### PR TITLE
Implement checkpoint loading

### DIFF
--- a/train.py
+++ b/train.py
@@ -5,6 +5,8 @@ which can be freely downloaded at the following site (~10 GB):
 http://homepages.inf.ed.ac.uk/jyamagis/page3/page58/page58.html
 '''
 
+from __future__ import print_function
+
 import argparse
 from datetime import datetime
 import glob
@@ -30,7 +32,7 @@ LOGDIR = './logdir'
 NUM_STEPS = 4000
 LEARNING_RATE = 0.02
 WAVENET_PARAMS = './wavenet_params.json'
-
+STARTED_DATESTRING = "{0:%Y-%m-%dT%H-%M-%S}".format(datetime.now())
 
 def get_arguments():
     parser = argparse.ArgumentParser(description='WaveNet example network')
@@ -42,9 +44,22 @@ def get_arguments():
                         help='Whether to store advanced debugging information '
                         '(execution time, memory consumption) for use with '
                         'TensorBoard.')
-    parser.add_argument('--logdir', type=str, default=LOGDIR,
+    parser.add_argument('--logdir', type=str, default=None,
                         help='Directory in which to store the logging '
-                        'information for TensorBoard.')
+                        'information for TensorBoard. '
+                        'If the model already exists, it will restore '
+                        'the state and will continue training. '
+                        'Cannot use with --logdir_root and --restore_from.')
+    parser.add_argument('--logdir_root', type=str, default=None,
+                        help='Root directory to place the logging '
+                        'output and generated model. These are stored '
+                        'under the dated subdirectory of --logdir_root. '
+                        'Cannot use with --logdir.')
+    parser.add_argument('--restore_from', type=str, default=None,
+                        help='Directory in which to restore the model from. '
+                        'This creates the new model under the dated directory '
+                        'in --logdir_root. '
+                        'Cannot use with --logdir.')
     parser.add_argument('--num_steps', type=int, default=NUM_STEPS,
                         help='Number of training steps.')
     parser.add_argument('--learning_rate', type=float, default=LEARNING_RATE,
@@ -52,6 +67,42 @@ def get_arguments():
     parser.add_argument('--wavenet_params', type=str, default=WAVENET_PARAMS,
                         help='JSON file with the network parameters.')
     return parser.parse_args()
+
+
+def save(saver, sess, logdir, step):
+    model_name = 'model.ckpt'
+    checkpoint_path = os.path.join(logdir, model_name)
+    print('Storing checkpoint to {} ...'.format(logdir), end="")
+
+    if not os.path.exists(logdir):
+        os.makedirs(logdir)
+
+    saver.save(sess, checkpoint_path, global_step=step)
+    print(' Done.')
+
+
+def load(saver, sess, logdir):
+    print("Trying to restore saved checkpoints from {} ...".format(logdir), end="")
+
+    ckpt = tf.train.get_checkpoint_state(logdir)
+    if ckpt:
+        print("")
+        print("  Checkpoint found: {}".format(ckpt.model_checkpoint_path))
+        global_step = int(ckpt.model_checkpoint_path.split('/')[-1].split('-')[-1])
+        print("  Global step was: {}".format(global_step))
+        print("  Restoring...", end="")
+        saver.restore(sess, ckpt.model_checkpoint_path)
+        print(" Done.")
+        return global_step
+    else:
+        print(" No checkpoint found.")
+        return None
+
+
+def get_default_logdir(logdir_root):
+    logdir = os.path.join(logdir_root, 'train', STARTED_DATESTRING)
+
+    return logdir
 
 
 def scan_directory(directory):
@@ -78,6 +129,53 @@ def iterate_through_vctk(directory, sample_rate):
         audio = audio.reshape(-1, 1)
         speaker_id, recording_id = [int(i) for i in speaker_re.findall(f)[0]]
         yield audio, speaker_id
+
+
+def validate_directories(args):
+    """
+    Validate and arrange directory related arguments.
+    """
+
+    # Validation
+    # ----------
+
+    if args.logdir and args.logdir_root:
+        raise ValueError("--logdir and --logdir_root cannot be "
+                         "specified at the same time.")
+
+    if args.logdir and args.restore_from:
+        raise ValueError("--logdir and --restore_from cannot be "
+                         "specified at the same time. This is to keep "
+                         "your previous model from unexpected overwrites.\n"
+                         "Use --logdir_root to specify the root of the directory "
+                         "which will be automatically created with current date "
+                         "and time, or use only --logdir to just continue the "
+                         "training from the last checkpoint.")
+
+    # Arrangement
+    # -----------
+
+    logdir_root = args.logdir_root
+    if logdir_root is None:
+        logdir_root = LOGDIR
+
+    logdir = args.logdir
+    if logdir is None:
+        logdir = get_default_logdir(logdir_root)
+        print ('Using default logdir: {}'.format(logdir))
+
+    restore_from = args.restore_from
+    if restore_from is None:
+        # args.logdir and args.restore_from is exclusive,
+        # So it is guranteed the logdir here is newly created.
+
+        restore_from = logdir
+
+    return {
+        'logdir': logdir,
+        'logdir_root': args.logdir_root,
+        'restore_from': restore_from
+    }
 
 
 class CustomRunner(object):
@@ -119,8 +217,21 @@ class CustomRunner(object):
 
 def main():
     args = get_arguments()
-    datestring = "{0:%Y-%m-%dT%H-%M-%S}".format(datetime.now())
-    logdir = os.path.join(args.logdir, 'train', datestring)
+
+    try:
+        directories = validate_directories(args)
+    except ValueError as e:
+        print("Some arguments are wrong:")
+        print(str(e))
+        return
+
+    logdir = directories['logdir']
+    logdir_root = directories['logdir_root']
+    restore_from = directories['restore_from']
+
+    # Even if we restored the model, we will treat it as new training
+    # if the trained model is written into arbitrary location.
+    is_new_training = logdir != restore_from
 
     with open(args.wavenet_params, 'r') as f:
         wavenet_params = json.load(f)
@@ -155,14 +266,31 @@ def main():
     sess = tf.Session(config=tf.ConfigProto(log_device_placement=False))
     init = tf.initialize_all_variables()
     sess.run(init)
-    threads = tf.train.start_queue_runners(sess=sess, coord=coord)
-    custom_runner.start_threads(sess)
 
     # Saver for storing checkpoints of the model.
     saver = tf.train.Saver()
 
     try:
-        for step in range(args.num_steps):
+        saved_global_step = load(saver, sess, restore_from)
+        if is_new_training or saved_global_step is None:
+            # For "new" training with using pre-trained model,
+            # We should ignore saved_global_step
+
+            # The training step is start from saved_global_step + 1
+            # Therefore put -1 here if the new training starts.
+            saved_global_step = -1
+
+    except:
+        print("Something is wrong while restoring checkpoint. "
+              "We will terminate training to avoid accidentally overwriting "
+              "the previous model.")
+        raise
+
+    threads = tf.train.start_queue_runners(sess=sess, coord=coord)
+    custom_runner.start_threads(sess)
+
+    try:
+        for step in range(saved_global_step + 1, args.num_steps):
             start_time = time.time()
             if args.store_metadata and step % 50 == 0:
                 # Slow run that stores extra information for debugging.
@@ -186,9 +314,7 @@ def main():
             print('step %d - loss = %.3f, (%.3f sec/step)' % (step, loss_value, duration))
 
             if step % 50 == 0:
-                checkpoint_path = os.path.join(logdir, 'model.ckpt')
-                print('Storing checkpoint to {}'.format(checkpoint_path))
-                saver.save(sess, checkpoint_path, global_step=step)
+                save(saver, sess, logdir, step)
 
     finally:
         coord.request_stop()


### PR DESCRIPTION
Will close #35. The latest checkpoint in `--logdir` can be restored.

This PR will change the behavior of `--logdir`.
 - With `--logdir`, `--logdir` is directly used as `logdir`.
 - Without `--logdir`, use `LOG_DIR/train/{datestring}` is used as `logdir` as before.

Possible concern is that someone may want to use `SOMEWHERE_THEY_NEED/train/{datestring}` for their first training (i.e., they need the app to make dated directory, but not under default `LOG_DIR`).

The solution is add a flag like `--default_logdir_root` to change `LOG_DIR` part, but it could the flags be complicated.