### PR TITLE
Fix AttributeError: 'module' object has no attribute 'client'

### DIFF
--- a/train.py
+++ b/train.py
@@ -22,7 +22,7 @@ import librosa
 
 import tensorflow as tf
 from tensorflow.contrib import ffmpeg
-import tensorflow.python.client.timeline as timeline
+from tensorflow.python.client import timeline
 
 from wavenet import WaveNet
 


### PR DESCRIPTION
A recent TensorFlow commit (tensorflow/tensorflow@5563229) removes the
visibility of several modules. For anyone using bleeding edge TF, this allows
importing of `timeline`.