### PR TITLE
Add biases

### DIFF
--- a/test/test_net.py
+++ b/test/test_net.py
@@ -25,16 +25,17 @@ def MakeSineWaves():
     return amplitudes
 
 
-class TestNet(tf.test.TestCase):
+class TestNetWithBiases(tf.test.TestCase):
     def setUp(self):
         quantization_steps=256
-        self.net = WaveNet(batch_size = 1,
-                           channels = quantization_steps,
+        self.net = WaveNet(batch_size=1,
+                           channels=quantization_steps,
                            dilations= [1, 2, 4, 8, 16, 32, 64, 128, 256,
                                        1, 2, 4, 8, 16, 32, 64, 128, 256],
                            filter_width=2,
-                           residual_channels = 16,
-                           dilation_channels = 16)
+                           residual_channels=16,
+                           dilation_channels=16,
+                           use_biases=True)
 
     # Train a net on a short clip of 3 sine waves superimposed (an e-flat chord)
     # Presumably it can overfit to such a simple signal. This test serves

--- a/train.py
+++ b/train.py
@@ -250,7 +250,8 @@ def main():
                   wavenet_params["dilations"],
                   wavenet_params["filter_width"],
                   wavenet_params["residual_channels"],
-                  wavenet_params["dilation_channels"])
+                  wavenet_params["dilation_channels"],
+                  wavenet_params["use_biases"])
     loss = net.loss(audio_batch)
     optimizer = tf.train.AdamOptimizer(learning_rate=args.learning_rate)
     trainable = tf.trainable_variables()

--- a/wavenet.py
+++ b/wavenet.py
@@ -18,13 +18,23 @@ class WaveNet(object):
                  dilations,
                  filter_width,
                  residual_channels,
-                 dilation_channels):
+                 dilation_channels,
+                 use_biases):
         self.batch_size = batch_size
         self.channels = channels
         self.dilations = dilations
         self.filter_width = filter_width
         self.residual_channels = residual_channels
         self.dilation_channels = dilation_channels
+        self.use_biases = use_biases
+        if (self.use_biases == True):
+            print "&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&"
+            print "use_biases is true!"
+            print "&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&"
+        else:
+            print "&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&"
+            print "use_biases is false!"
+            print "&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&"
 
 
     # A single causal convolution layer that can change the number of channels.
@@ -44,37 +54,49 @@ class WaveNet(object):
             [self.filter_width, in_channels, dilation_channels],
             stddev=0.2,
             name="filter"))
-        biases_filter = tf.Variable(tf.constant(0.0, shape=[dilation_channels]),
+        if self.use_biases:
+          print "Using biases!!"
+          biases_filter = tf.Variable(tf.constant(0.0, shape=[dilation_channels]),
                                     name="filter_biases")
+        else:
+          print "NOT using biases!"
 
         weights_gate = tf.Variable(tf.truncated_normal(
             [self.filter_width, in_channels, dilation_channels],
             stddev=0.2, name="gate"))
-        biases_gate = tf.Variable(tf.constant(0.0, shape=[dilation_channels]),
+
+        if self.use_biases:
+          biases_gate = tf.Variable(tf.constant(0.0, shape=[dilation_channels]),
                                   name="gate_biases")
 
         conv_filter = causal_conv(input_batch, weights_filter, dilation)
-        conv_filter = tf.add(conv_filter, biases_filter)
+        if self.use_biases:
+          conv_filter = tf.add(conv_filter, biases_filter)
 
         conv_gate = causal_conv(input_batch, weights_gate, dilation)
-        conv_gate = tf.add(conv_gate, biases_gate)
+        if self.use_biases:
+          conv_gate = tf.add(conv_gate, biases_gate)
 
         out = tf.tanh(conv_filter) * tf.sigmoid(conv_gate)
 
         weights_dense = tf.Variable(tf.truncated_normal(
             [1, dilation_channels, in_channels], stddev=0.2, name="dense"))
-        biases_dense = tf.Variable(tf.constant(0.0,shape=[in_channels]),
+
+        if self.use_biases:
+          biases_dense = tf.Variable(tf.constant(0.0,shape=[in_channels]),
                                    name="dense_biases")
         transformed = tf.nn.conv1d(out, weights_dense, stride=1,
                                    padding="SAME", name="dense")
-        transformed = tf.add(transformed, biases_dense)
+        if self.use_biases:
+          transformed = tf.add(transformed, biases_dense)
         layer = 'layer{}'.format(layer_index)
         tf.histogram_summary(layer + '_filter', weights_filter)
         tf.histogram_summary(layer + '_gate', weights_gate)
         tf.histogram_summary(layer + '_dense', weights_dense)
-        tf.histogram_summary(layer + '_biases_filter', biases_filter)
-        tf.histogram_summary(layer + '_biases_gate', biases_gate)
-        tf.histogram_summary(layer + '_biases_dense', biases_dense)
+        if self.use_biases:
+          tf.histogram_summary(layer + '_biases_filter', biases_filter)
+          tf.histogram_summary(layer + '_biases_gate', biases_gate)
+          tf.histogram_summary(layer + '_biases_dense', biases_dense)
 
         return transformed, input_batch + transformed
 
@@ -124,28 +146,33 @@ class WaveNet(object):
             w1 = tf.Variable(tf.truncated_normal(
                 [1, self.residual_channels, int(self.channels / 2)], stddev=0.3,
                 name="postprocess1"))
-            b1 = tf.Variable(tf.constant(0.0, shape=[int(self.channels/2)]),
-                name="postprocess1_bias")
+            if self.use_biases:
+              b1 = tf.Variable(tf.constant(0.0, shape=[int(self.channels/2)]),
+                  name="postprocess1_bias")
             w2 = tf.Variable(tf.truncated_normal(
                 [1, int(self.channels / 2), self.channels], stddev=0.3,
                 name="postprocess2"))
-            b2 = tf.Variable(tf.constant(0.0, shape=[self.channels]),
-                name="postprocess2_bias")
+            if self.use_biases:
+              b2 = tf.Variable(tf.constant(0.0, shape=[self.channels]),
+                  name="postprocess2_bias")
 
             tf.histogram_summary('postprocess1_weights', w1)
             tf.histogram_summary('postprocess2_weights', w2)
-            tf.histogram_summary('postprocess1_biases', b1)
-            tf.histogram_summary('postprocess2_biases', b2)
+            if self.use_biases:
+              tf.histogram_summary('postprocess1_biases', b1)
+              tf.histogram_summary('postprocess2_biases', b2)
 
             # We skip connections from the outputs of each layer, adding them
             # all up here.
             total = sum(outputs)
             transformed1 = tf.nn.relu(total)
             conv1 = tf.nn.conv1d(transformed1, w1, stride=1, padding="SAME")
-            conv1 = tf.add(conv1, b1)
+            if self.use_biases:
+              conv1 = tf.add(conv1, b1)
             transformed2 = tf.nn.relu(conv1)
             conv2 = tf.nn.conv1d(transformed2, w2, stride=1, padding="SAME")
-            conv2 = tf.add(conv2, b2)
+            if self.use_biases:
+              conv2 = tf.add(conv2, b2)
 
         return conv2
 

--- a/wavenet.py
+++ b/wavenet.py
@@ -51,7 +51,7 @@ class WaveNet(object):
             [self.filter_width, in_channels, dilation_channels],
             stddev=0.2, name="gate"))
         biases_gate = tf.Variable(tf.constant(0.0, shape=[dilation_channels]),
-                                  name="filter_biases")
+                                  name="gate_biases")
 
         conv_filter = causal_conv(input_batch, weights_filter, dilation)
         conv_filter = tf.add(conv_filter, biases_filter)
@@ -63,12 +63,18 @@ class WaveNet(object):
 
         weights_dense = tf.Variable(tf.truncated_normal(
             [1, dilation_channels, in_channels], stddev=0.2, name="dense"))
+        biases_dense = tf.Variable(tf.constant(0.0,shape=[in_channels]),
+                                   name="dense_biases")
         transformed = tf.nn.conv1d(out, weights_dense, stride=1,
                                    padding="SAME", name="dense")
+        transformed = tf.add(transformed, biases_dense)
         layer = 'layer{}'.format(layer_index)
         tf.histogram_summary(layer + '_filter', weights_filter)
         tf.histogram_summary(layer + '_gate', weights_gate)
         tf.histogram_summary(layer + '_dense', weights_dense)
+        tf.histogram_summary(layer + '_biases_filter', biases_filter)
+        tf.histogram_summary(layer + '_biases_gate', biases_gate)
+        tf.histogram_summary(layer + '_biases_dense', biases_dense)
 
         return transformed, input_batch + transformed
 
@@ -118,20 +124,28 @@ class WaveNet(object):
             w1 = tf.Variable(tf.truncated_normal(
                 [1, self.residual_channels, int(self.channels / 2)], stddev=0.3,
                 name="postprocess1"))
+            b1 = tf.Variable(tf.constant(0.0, shape=[int(self.channels/2)]),
+                name="postprocess1_bias")
             w2 = tf.Variable(tf.truncated_normal(
                 [1, int(self.channels / 2), self.channels], stddev=0.3,
                 name="postprocess2"))
+            b2 = tf.Variable(tf.constant(0.0, shape=[self.channels]),
+                name="postprocess2_bias")
 
             tf.histogram_summary('postprocess1_weights', w1)
             tf.histogram_summary('postprocess2_weights', w2)
+            tf.histogram_summary('postprocess1_biases', b1)
+            tf.histogram_summary('postprocess2_biases', b2)
 
             # We skip connections from the outputs of each layer, adding them
             # all up here.
             total = sum(outputs)
             transformed1 = tf.nn.relu(total)
             conv1 = tf.nn.conv1d(transformed1, w1, stride=1, padding="SAME")
+            conv1 = tf.add(conv1, b1)
             transformed2 = tf.nn.relu(conv1)
             conv2 = tf.nn.conv1d(transformed2, w2, stride=1, padding="SAME")
+            conv2 = tf.add(conv2, b2)
 
         return conv2
 

--- a/wavenet.py
+++ b/wavenet.py
@@ -44,12 +44,20 @@ class WaveNet(object):
             [self.filter_width, in_channels, dilation_channels],
             stddev=0.2,
             name="filter"))
+        biases_filter = tf.Variable(tf.constant(0.0, shape=[dilation_channels]),
+                                    name="filter_biases")
+
         weights_gate = tf.Variable(tf.truncated_normal(
             [self.filter_width, in_channels, dilation_channels],
             stddev=0.2, name="gate"))
+        biases_gate = tf.Variable(tf.constant(0.0, shape=[dilation_channels]),
+                                  name="filter_biases")
 
         conv_filter = causal_conv(input_batch, weights_filter, dilation)
+        conv_filter = tf.add(conv_filter, biases_filter)
+
         conv_gate = causal_conv(input_batch, weights_gate, dilation)
+        conv_gate = tf.add(conv_gate, biases_gate)
 
         out = tf.tanh(conv_filter) * tf.sigmoid(conv_gate)
 

--- a/wavenet.py
+++ b/wavenet.py
@@ -67,17 +67,17 @@ class WaveNet(object):
         transformed = tf.nn.conv1d(out, weights_dense, stride=1,
                                    padding="SAME", name="dense")
         if self.use_biases:
-          biases_dense = tf.Variable(tf.constant(0.0,shape=[in_channels]),
-                                   name="dense_biases")
-          transformed = tf.add(transformed, biases_dense)
+            biases_dense = tf.Variable(tf.constant(0.0,shape=[in_channels]),
+                                       name="dense_biases")
+            transformed = tf.add(transformed, biases_dense)
         layer = 'layer{}'.format(layer_index)
         tf.histogram_summary(layer + '_filter', weights_filter)
         tf.histogram_summary(layer + '_gate', weights_gate)
         tf.histogram_summary(layer + '_dense', weights_dense)
         if self.use_biases:
-          tf.histogram_summary(layer + '_biases_filter', biases_filter)
-          tf.histogram_summary(layer + '_biases_gate', biases_gate)
-          tf.histogram_summary(layer + '_biases_dense', biases_dense)
+            tf.histogram_summary(layer + '_biases_filter', biases_filter)
+            tf.histogram_summary(layer + '_biases_gate', biases_gate)
+            tf.histogram_summary(layer + '_biases_dense', biases_dense)
 
         return transformed, input_batch + transformed
 
@@ -131,16 +131,16 @@ class WaveNet(object):
                 [1, int(self.channels / 2), self.channels], stddev=0.3,
                 name="postprocess2"))
             if self.use_biases:
-              b1 = tf.Variable(tf.constant(0.0, shape=[int(self.channels/2)]),
-                  name="postprocess1_bias")
-              b2 = tf.Variable(tf.constant(0.0, shape=[self.channels]),
-                  name="postprocess2_bias")
+                b1 = tf.Variable(tf.constant(0.0, shape=[int(self.channels/2)]),
+                                 name="postprocess1_bias")
+                b2 = tf.Variable(tf.constant(0.0, shape=[self.channels]),
+                                 name="postprocess2_bias")
 
             tf.histogram_summary('postprocess1_weights', w1)
             tf.histogram_summary('postprocess2_weights', w2)
             if self.use_biases:
-              tf.histogram_summary('postprocess1_biases', b1)
-              tf.histogram_summary('postprocess2_biases', b2)
+                tf.histogram_summary('postprocess1_biases', b1)
+                tf.histogram_summary('postprocess2_biases', b2)
 
             # We skip connections from the outputs of each layer, adding them
             # all up here.
@@ -148,11 +148,11 @@ class WaveNet(object):
             transformed1 = tf.nn.relu(total)
             conv1 = tf.nn.conv1d(transformed1, w1, stride=1, padding="SAME")
             if self.use_biases:
-              conv1 = tf.add(conv1, b1)
+                conv1 = tf.add(conv1, b1)
             transformed2 = tf.nn.relu(conv1)
             conv2 = tf.nn.conv1d(transformed2, w2, stride=1, padding="SAME")
             if self.use_biases:
-              conv2 = tf.add(conv2, b2)
+                conv2 = tf.add(conv2, b2)
 
         return conv2
 

--- a/wavenet.py
+++ b/wavenet.py
@@ -53,18 +53,17 @@ class WaveNet(object):
         conv_gate = causal_conv(input_batch, weights_gate, dilation)
 
         if self.use_biases:
-          biases_filter = tf.Variable(tf.constant(0.0, shape=[dilation_channels]),
-                                    name="filter_biases")
-          biases_gate = tf.Variable(tf.constant(0.0, shape=[dilation_channels]),
-                                  name="gate_biases")
-          conv_filter = tf.add(conv_filter, biases_filter)
-          conv_gate = tf.add(conv_gate, biases_gate)
+            biases_filter = tf.Variable(tf.constant(0.0, shape=[dilation_channels]),
+                                        name="filter_biases")
+            biases_gate = tf.Variable(tf.constant(0.0, shape=[dilation_channels]),
+                                      name="gate_biases")
+            conv_filter = tf.add(conv_filter, biases_filter)
+            conv_gate = tf.add(conv_gate, biases_gate)
 
         out = tf.tanh(conv_filter) * tf.sigmoid(conv_gate)
 
         weights_dense = tf.Variable(tf.truncated_normal(
             [1, dilation_channels, in_channels], stddev=0.2, name="dense"))
-
         transformed = tf.nn.conv1d(out, weights_dense, stride=1,
                                    padding="SAME", name="dense")
         if self.use_biases:

--- a/wavenet_params.json
+++ b/wavenet_params.json
@@ -5,5 +5,7 @@
     "dilations": [1, 2, 4, 8, 16, 32, 64, 128, 256,
                   1, 2, 4, 8, 16, 32, 64, 128, 256],
     "residual_channels": 32,
-    "dilation_channels": 16
+    "dilation_channels":16,
+    "use_biases": false
+>>>>>>> Bool param to include or exclude biases.
 }

--- a/wavenet_params.json
+++ b/wavenet_params.json
@@ -6,5 +6,5 @@
                   1, 2, 4, 8, 16, 32, 64, 128, 256],
     "residual_channels": 32,
     "dilation_channels":16,
-    "use_biases": true
+    "use_biases": false
 }

--- a/wavenet_params.json
+++ b/wavenet_params.json
@@ -6,6 +6,5 @@
                   1, 2, 4, 8, 16, 32, 64, 128, 256],
     "residual_channels": 32,
     "dilation_channels":16,
-    "use_biases": false
->>>>>>> Bool param to include or exclude biases.
+    "use_biases": true
 }


### PR DESCRIPTION
This is the successor to [PR 39](https://github.com/ibab/tensorflow-wavenet/pull/39). It allows one to specify use_biases: true in wavenet_params.json to enable them.

Training with and without biases didn't show a material difference in the loss vs time in the experiment I did. 

I defaulted use_biases to false in wavenet_params.json.