### PR TITLE
Adjust network

### DIFF
--- a/wavenet_params.json
+++ b/wavenet_params.json
@@ -2,8 +2,9 @@
     "filter_width": 2,
     "quantization_steps": 256,
     "sample_rate": 16000,
-    "dilations": [1, 2, 4, 8, 16, 32, 64, 128, 256,
-                  1, 2, 4, 8, 16, 32, 64, 128, 256],
+    "dilations": [1, 2, 4, 8, 16, 32, 64, 128, 256, 512,
+                  1, 2, 4, 8, 16, 32, 64, 128, 256, 512,
+                  1, 2, 4, 8, 16, 32, 64, 128, 256, 512],
     "residual_channels": 32,
     "dilation_channels": 16
 }


### PR DESCRIPTION
Multiple adjustments to the model definition:

1. Use separate 1x1 convolutions for residuals and skipped connections (suggested by @basveeling)
2. We can feed the raw waveform into the first convolutional layer instead of a one-hot encoding (as explained by @jyegerlehner)
3. Made the histogram summaries optional

I'm not super sure about 2 yet, it seems to produce roughly similar results to the one-hot encoding.
And it would probably be better to use quantized values instead of the original signal.