### PR TITLE
Xavier initialization

### DIFF
--- a/wavenet.py
+++ b/wavenet.py
@@ -1,6 +1,7 @@
 import tensorflow as tf
 
-from wavenet_ops import causal_conv, mu_law_encode
+from wavenet_ops import causal_conv, mu_law_encode, create_variable, \
+                        create_bias_variable
 
 
 class WaveNet(object):
@@ -66,12 +67,10 @@ class WaveNet(object):
         
         The layer can change the number of channels.
         '''
-        with tf.name_scope('causal_layer'):
-            weights_filter = tf.Variable(
-                tf.truncated_normal(
-                    [self.filter_width, in_channels, out_channels],
-                    stddev=0.2,
-                    name="filter"))
+        with tf.variable_scope('causal_layer'):
+            weights_filter = create_variable("filter", [self.filter_width,
+                                                        in_channels,
+                                                        out_channels])
             return causal_conv(input_batch, weights_filter, 1)
 
     def _create_dilation_layer(self, input_batch, layer_index, dilation,
@@ -90,57 +89,42 @@ class WaveNet(object):
         Where `[gate]` and `[filter]` are causal convolutions with a
         non-linear activation at the output.
         '''
-        weights_filter = tf.Variable(
-            tf.truncated_normal(
-                [self.filter_width, in_channels, dilation_channels],
-                stddev=0.2,
-                name="filter"))
-        weights_gate = tf.Variable(
-            tf.truncated_normal(
-                [self.filter_width, in_channels, dilation_channels],
-                stddev=0.2,
-                name="gate"))
+        weights_filter = create_variable("filter", [self.filter_width,
+                                                    in_channels,
+                                                    dilation_channels])
+        weights_gate = create_variable("gate", [self.filter_width,
+                                                in_channels,
+                                                dilation_channels])
 
         conv_filter = causal_conv(input_batch, weights_filter, dilation)
         conv_gate = causal_conv(input_batch, weights_gate, dilation)
 
         if self.use_biases:
-            biases_filter = tf.Variable(
-                tf.constant(
-                    0.0, shape=[dilation_channels]),
-                name="filter_biases")
-            biases_gate = tf.Variable(
-                tf.constant(
-                    0.0, shape=[dilation_channels]),
-                name="gate_biases")
+            biases_filter = create_bias_variable("filter_biases",
+                                                 [dilation_channels])
+            biases_gate = create_bias_variable("filter_biases",
+                                               [dilation_channels])
             conv_filter = tf.add(conv_filter, biases_filter)
             conv_gate = tf.add(conv_gate, biases_gate)
 
         out = tf.tanh(conv_filter) * tf.sigmoid(conv_gate)
 
         # The 1x1 conv to produce the dense contribution.
-        weights_dense = tf.Variable(
-            tf.truncated_normal(
-                [1, dilation_channels, in_channels], stddev=0.2, name="dense"))
+        weights_dense = create_variable("dense", [1, dilation_channels,
+                                                     in_channels])
         transformed = tf.nn.conv1d(
             out, weights_dense, stride=1, padding="SAME", name="dense")
 
         # The 1x1 conv to produce the skip contribution.
-        weights_skip = tf.Variable(
-            tf.truncated_normal(
-                [1, dilation_channels, skip_channels], stddev=0.01),
-            name="skip")
+        weights_skip = create_variable("skip", [1, dilation_channels,
+                                                skip_channels])
         skip_contribution = tf.nn.conv1d(
             out, weights_skip, stride=1, padding="SAME", name="skip")
-                
+
         if self.use_biases:
-            biases_dense = tf.Variable(
-                tf.constant(
-                    0.0, shape=[in_channels]), name="dense_biases")
+            biases_dense = create_bias_variable("dense_biases", [in_channels])
             transformed = tf.add(transformed, biases_dense)
-            biases_skip = tf.Variable(
-                tf.constant(
-                    0.0, shape=[skip_channels]), name="skip_biases")
+            biases_skip = create_bias_variable("skip_biases", [skip_channels])
             skip_contribution = tf.add(skip_contribution, biases_skip)
 
         layer = 'layer{}'.format(layer_index)
@@ -225,7 +209,7 @@ class WaveNet(object):
         # Add all defined dilation layers.
         with tf.name_scope('dilated_stack'):
             for layer_index, dilation in enumerate(self.dilations):
-                with tf.name_scope('layer{}'.format(layer_index)):
+                with tf.variable_scope('layer{}'.format(layer_index)):
                     output, current_layer = self._create_dilation_layer(
                         current_layer, layer_index, dilation,
                         self.residual_channels, self.dilation_channels,
@@ -235,25 +219,15 @@ class WaveNet(object):
         with tf.name_scope('postprocessing'):
             # Perform (+) -> ReLU -> 1x1 conv -> ReLU -> 1x1 conv to
             # postprocess the output.
-            w1 = tf.Variable(
-                tf.truncated_normal(
-                    [1, self.skip_channels, self.skip_channels],
-                    stddev=0.3,
-                    name="postprocess1"))
-            w2 = tf.Variable(
-                tf.truncated_normal(
-                    [1, self.skip_channels, self.quantization_channels],
-                    stddev=0.3,
-                    name="postprocess2"))
+            w1 = create_variable("postprocess1", [1, self.skip_channels,
+                                                  self.skip_channels])
+            w2 = create_variable("postprocess2", [1, self.skip_channels,
+                                                  self.quantization_channels])
             if self.use_biases:
-                b1 = tf.Variable(
-                    tf.constant(
-                        0.0, shape=[self.skip_channels]),
-                    name="postprocess1_bias")
-                b2 = tf.Variable(
-                    tf.constant(
-                        0.0, shape=[self.quantization_channels]),
-                    name="postprocess2_bias")
+                b1 = create_bias_variable("postprocess1_bias",
+                                          [self.skip_channels])
+                b2 = create_bias_variable("postprocess2_bias",
+                                          [self.quantization_channels])
 
             tf.histogram_summary('postprocess1_weights', w1)
             tf.histogram_summary('postprocess2_weights', w2)
@@ -371,6 +345,9 @@ class WaveNet(object):
         with tf.variable_scope(name):
             encoded = self._one_hot(waveform)
             if self.fast_generation:
+                if self.use_biases:
+                    raise RuntimeError("Fast generation does not support" \
+                                       " biases.")
                 raw_output = self._create_generator(encoded)
             else:
                 raw_output = self._create_network(encoded)

--- a/wavenet.py
+++ b/wavenet.py
@@ -67,7 +67,7 @@ class WaveNet(object):
         
         The layer can change the number of channels.
         '''
-        with tf.variable_scope('causal_layer'):
+        with tf.name_scope('causal_layer'):
             weights_filter = create_variable("filter", [self.filter_width,
                                                         in_channels,
                                                         out_channels])
@@ -209,7 +209,7 @@ class WaveNet(object):
         # Add all defined dilation layers.
         with tf.name_scope('dilated_stack'):
             for layer_index, dilation in enumerate(self.dilations):
-                with tf.variable_scope('layer{}'.format(layer_index)):
+                with tf.name_scope('layer{}'.format(layer_index)):
                     output, current_layer = self._create_dilation_layer(
                         current_layer, layer_index, dilation,
                         self.residual_channels, self.dilation_channels,
@@ -342,7 +342,7 @@ class WaveNet(object):
 
     def predict_proba(self, waveform, name='wavenet'):
         '''Computes the probability distribution of the next sample.'''
-        with tf.variable_scope(name):
+        with tf.name_scope(name):
             encoded = self._one_hot(waveform)
             if self.fast_generation:
                 if self.use_biases:
@@ -362,7 +362,7 @@ class WaveNet(object):
 
         The variables are all scoped to the given name.
         '''
-        with tf.variable_scope(name):
+        with tf.name_scope(name):
             input_batch = mu_law_encode(input_batch,
                                         self.quantization_channels)
             encoded = self._one_hot(input_batch)

--- a/wavenet_ops.py
+++ b/wavenet_ops.py
@@ -3,6 +3,21 @@ from __future__ import division
 import tensorflow as tf
 
 
+# Create a convolution filter variable with the specified name and shape,
+# and initialize it using xavier initialization.
+def create_variable(name, shape):
+    initializer = tf.contrib.layers.xavier_initializer_conv2d()
+    variable = tf.get_variable(name, shape=shape, initializer=initializer)
+    return variable
+
+
+# Create a bias variable with the specified name and shape and initialize
+# it to zero.
+def create_bias_variable(name, shape):
+    initializer = tf.constant_initializer(value=0.0, dtype=tf.float32)
+    return tf.get_variable(name, shape=shape, initializer=initializer)
+
+
 def time_to_batch(value, dilation, name=None):
     with tf.name_scope('time_to_batch'):
         shape = tf.shape(value)

--- a/wavenet_ops.py
+++ b/wavenet_ops.py
@@ -6,8 +6,10 @@ import tensorflow as tf
 # Create a convolution filter variable with the specified name and shape,
 # and initialize it using xavier initialization.
 def create_variable(name, shape):
+    #    initializer = tf.contrib.layers.xavier_initializer_conv2d()
+    #    variable = tf.get_variable(name, shape=shape, initializer=initializer)
     initializer = tf.contrib.layers.xavier_initializer_conv2d()
-    variable = tf.get_variable(name, shape=shape, initializer=initializer)
+    variable = tf.Variable(initializer(shape=shape), name=name)
     return variable
 
 
@@ -15,7 +17,7 @@ def create_variable(name, shape):
 # it to zero.
 def create_bias_variable(name, shape):
     initializer = tf.constant_initializer(value=0.0, dtype=tf.float32)
-    return tf.get_variable(name, shape=shape, initializer=initializer)
+    return tf.Variable(initializer(shape=shape), name)
 
 
 def time_to_batch(value, dilation, name=None):


### PR DESCRIPTION
As discussed [here](https://github.com/ibab/tensorflow-wavenet/issues/42).

Regarding the failing test:  I guess the problem is that we switched from tf.Variable() to tf.get_variable(), and the self.net member variable is being re-used within the tf.test.TestCase.test_session. The second test tries to create a graph with all the same variable names. 
```
ValueError: Variable wavenet/causal_layer/filter already exists, disallowed. Did you mean to set reuse=True in VarScope? 
```
I tried for hours to refactor that with no success. I'm a C++ person, OK? I just flounder around in python. It usually works out. Any chance one of you python people could point me in the right direction please?
