### PR TITLE
Restructure code and test generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ python generate.py --wav_out_path=generated.wav --save_every 2000 --samples 1600
 ```
 
 Fast generation is enabled by default.
-It uses the implementation from the [Fast Wavenet](https://github.com/tomlepaine/fast-wavenet) repository. You can follow the link for an explanation of how it works. This reduces the time needed to generate samples to a few minutes.
+It uses the implementation from the [Fast Wavenet](https://github.com/tomlepaine/fast-wavenet) repository.
 You can follow the link for an explanation of how it works.
 This reduces the time needed to generate samples to a few minutes.
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,10 @@ Passing `--save_every` in addition to `--wav_out_path` will save the in-progress
 python generate.py --wav_out_path=generated.wav --save_every 2000 --samples 16000 model.ckpt-1000
 ```
 
-Fast generation is enabled by default. It uses the implementation from the [Fast Wavenet](https://github.com/tomlepaine/fast-wavenet) repository. You can follow the link for an explanation of how it works. This reduces the time needed to generate samples to a few minutes.
+Fast generation is enabled by default.
+It uses the implementation from the [Fast Wavenet](https://github.com/tomlepaine/fast-wavenet) repository. You can follow the link for an explanation of how it works. This reduces the time needed to generate samples to a few minutes.
+You can follow the link for an explanation of how it works.
+This reduces the time needed to generate samples to a few minutes.
 
 To disable fast generation:
 ```

--- a/generate.py
+++ b/generate.py
@@ -144,9 +144,9 @@ def main():
         # When using the incremental generation, we need to
         # feed in all priming samples one by one before starting the
         # actual generation.
-        # TODO This can be done much more efficiently by passing the waveform
-        # to the incremental generation function and filling the queues with it
-        # instead of zeros.
+        # TODO This could be done much more efficiently by passing the waveform
+        # to the incremental generator as an optional argument, which would be
+        # used to fill the queues initially.
         outputs = [next_sample]
         outputs.extend(net.push_ops)
 

--- a/generate.py
+++ b/generate.py
@@ -9,8 +9,7 @@ import librosa
 import numpy as np
 import tensorflow as tf
 
-from wavenet import WaveNet
-from wavenet_ops import mu_law_decode, mu_law_encode
+from wavenet import WaveNetModel, mu_law_encode, mu_law_decode
 
 SAMPLES = 16000
 LOGDIR = './logdir'
@@ -23,7 +22,8 @@ def get_arguments():
     def _str_to_bool(s):
         """Convert string to bool (in argparse context)."""
         if s.lower() not in ['true', 'false']:
-            raise ValueError('Argument needs to be a boolean, got {}'.format(s))
+            raise ValueError('Argument needs to be a '
+                             'boolean, got {}'.format(s))
         return {'true': True, 'false': False}[s.lower()]
 
     parser = argparse.ArgumentParser(description='WaveNet generation script')
@@ -63,8 +63,8 @@ def get_arguments():
         help='How many samples before saving in-progress wav')
     parser.add_argument(
         '--fast_generation',
-        default=True,
         type=_str_to_bool,
+        default=True,
         help='Use fast generation')
     parser.add_argument(
         '--wav_seed',
@@ -79,13 +79,18 @@ def write_wav(waveform, sample_rate, filename):
     librosa.output.write_wav(filename, y, sample_rate)
     print('Updated wav file at {}'.format(filename))
 
-def create_seed(filename, sample_rate, quantization_channels, window_size=WINDOW):
+
+def create_seed(filename,
+                sample_rate,
+                quantization_channels,
+                window_size=WINDOW):
     audio, _ = librosa.load(filename, sr=sample_rate, mono=True)
 
     quantized = mu_law_encode(audio, quantization_channels)
     cut_index = tf.size(quantized) + tf.constant(window_size) - tf.constant(1)
 
     return quantized[:cut_index]
+
 
 def main():
     args = get_arguments()
@@ -95,7 +100,7 @@ def main():
 
     sess = tf.Session()
 
-    net = WaveNet(
+    net = WaveNetModel(
         batch_size=1,
         dilations=wavenet_params['dilations'],
         filter_width=wavenet_params['filter_width'],
@@ -103,19 +108,22 @@ def main():
         dilation_channels=wavenet_params['dilation_channels'],
         quantization_channels=wavenet_params['quantization_channels'],
         skip_channels=wavenet_params['skip_channels'],
-        use_biases=wavenet_params['use_biases'],
-        fast_generation=args.fast_generation)
+        use_biases=wavenet_params['use_biases'])
 
     samples = tf.placeholder(tf.int32)
 
-    next_sample = net.predict_proba(samples)
+    if args.fast_generation:
+        next_sample = net.predict_proba_incremental(samples)
+    else:
+        next_sample = net.predict_proba(samples)
 
     if args.fast_generation:
         sess.run(tf.initialize_all_variables())
         sess.run(net.init_ops)
 
-    variables_to_restore = {var.name[:-2]: var for var in tf.all_variables(
-    ) if not ('state_buffer' in var.name or 'pointer' in var.name)}
+    variables_to_restore = {
+        var.name[:-2]: var for var in tf.all_variables()
+        if not ('state_buffer' in var.name or 'pointer' in var.name)}
     saver = tf.train.Saver(variables_to_restore)
 
     print('Restoring model from {}'.format(args.checkpoint))
@@ -126,17 +134,34 @@ def main():
     quantization_channels = wavenet_params['quantization_channels']
     if args.wav_seed:
         seed = create_seed(args.wav_seed,
-                    wavenet_params['sample_rate'],
-                    quantization_channels)
+                           wavenet_params['sample_rate'],
+                           quantization_channels)
         waveform = sess.run(seed).tolist()
     else:
         waveform = np.random.randint(quantization_channels, size=(1,)).tolist()
 
+    if args.fast_generation and args.wav_seed:
+        # When using the incremental generation, we need to
+        # feed in all priming samples one by one before starting the
+        # actual generation.
+        # TODO This can be done much more efficiently by passing the waveform
+        # to the incremental generation function and filling the queues with it
+        # instead of zeros.
+        outputs = [next_sample]
+        outputs.extend(net.push_ops)
+
+        print('Priming generation...')
+        for i, x in enumerate(waveform[:-(args.window + 1)]):
+            if i % 100 == 0:
+                print('Priming sample {}'.format(i))
+            sess.run(outputs, feed_dict={samples: x})
+        print('Done.')
+
     for step in range(args.samples):
         if args.fast_generation:
-            window = waveform[-1]
             outputs = [next_sample]
             outputs.extend(net.push_ops)
+            window = waveform[-1]
         else:
             if len(waveform) > args.window:
                 window = waveform[-args.window:]

--- a/test/test_causal_conv.py
+++ b/test/test_causal_conv.py
@@ -3,7 +3,7 @@
 import numpy as np
 import tensorflow as tf
 
-from wavenet_ops import time_to_batch, batch_to_time, causal_conv
+from wavenet import time_to_batch, batch_to_time, causal_conv
 
 
 class TestCausalConv(tf.test.TestCase):

--- a/test/test_generation.py
+++ b/test/test_generation.py
@@ -72,5 +72,18 @@ class TestGeneration(tf.test.TestCase):
             self.assertAllClose(proba_, proba_fast_)
 
 
+class TestGenerationBiases(TestGeneration):
+
+    def setUp(self):
+        self.net = WaveNetModel(batch_size=1,
+                                dilations=[1, 2, 4, 8, 16, 32, 64, 128, 256],
+                                filter_width=2,
+                                use_biases=True,
+                                residual_channels=16,
+                                dilation_channels=16,
+                                quantization_channels=128,
+                                skip_channels=32)
+
+
 if __name__ == '__main__':
     tf.test.main()

--- a/test/test_generation.py
+++ b/test/test_generation.py
@@ -1,0 +1,76 @@
+import numpy as np
+
+import tensorflow as tf
+
+from wavenet import WaveNetModel
+
+
+class TestGeneration(tf.test.TestCase):
+
+    def setUp(self):
+        self.net = WaveNetModel(batch_size=1,
+                                dilations=[1, 2, 4, 8, 16, 32, 64, 128, 256],
+                                filter_width=2,
+                                residual_channels=16,
+                                dilation_channels=16,
+                                quantization_channels=128,
+                                skip_channels=32)
+
+    def testGenerateSimple(self):
+        '''Generate a few samples using the naive method and
+        perform sanity checks on the output.'''
+        waveform = tf.placeholder(tf.int32)
+        np.random.seed(0)
+        data = np.random.randint(128, size=1000)
+        proba = self.net.predict_proba(waveform)
+
+        with self.test_session() as sess:
+            sess.run(tf.initialize_all_variables())
+            proba = sess.run(proba, feed_dict={waveform: data})
+
+        self.assertAllEqual(proba.shape, [128])
+        self.assertTrue(np.all((proba >= 0) & (proba <= (128 - 1))))
+
+    def testGenerateFast(self):
+        '''Generate a few samples using the fast method and
+        perform sanity checks on the output.'''
+        waveform = tf.placeholder(tf.int32)
+        np.random.seed(0)
+        data = np.random.randint(128)
+        proba = self.net.predict_proba_incremental(waveform)
+
+        with self.test_session() as sess:
+            sess.run(tf.initialize_all_variables())
+            sess.run(self.net.init_ops)
+            proba = sess.run(proba, feed_dict={waveform: data})
+
+        self.assertAllEqual(proba.shape, [128])
+        self.assertTrue(np.all((proba >= 0) & (proba <= (128 - 1))))
+
+    def testCompareSimpleFast(self):
+        waveform = tf.placeholder(tf.int32)
+        np.random.seed(0)
+        data = np.random.randint(128, size=1)
+        proba = self.net.predict_proba(waveform)
+        proba_fast = self.net.predict_proba_incremental(waveform)
+        with self.test_session() as sess:
+            sess.run(tf.initialize_all_variables())
+            sess.run(self.net.init_ops)
+            # Prime the incremental generation with all samples
+            # except the last one
+            for x in data[:-1]:
+                proba_fast_ = sess.run(
+                    [proba_fast, self.net.push_ops],
+                    feed_dict={waveform: x})
+
+            # Get the last sample from the incremental generator
+            proba_fast_ = sess.run(
+                proba_fast,
+                feed_dict={waveform: data[-1]})
+            # Get the sample from the simple generator
+            proba_ = sess.run(proba, feed_dict={waveform: data})
+            self.assertAllClose(proba_, proba_fast_)
+
+
+if __name__ == '__main__':
+    tf.test.main()

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -56,7 +56,7 @@ class TestNet(tf.test.TestCase):
         optim = optimizer.minimize(loss, var_list=trainable)
         init = tf.initialize_all_variables()
 
-        max_allowed_loss = 0.2
+        max_allowed_loss = 0.1
         loss_val = max_allowed_loss
         initial_loss = None
         with self.test_session() as sess:

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -5,8 +5,7 @@ import json
 import numpy as np
 import tensorflow as tf
 
-from wavenet import WaveNet
-from wavenet_ops import time_to_batch, batch_to_time, causal_conv
+from wavenet import WaveNetModel, time_to_batch, batch_to_time, causal_conv
 
 
 def MakeSineWaves():
@@ -30,14 +29,14 @@ def MakeSineWaves():
 class TestNet(tf.test.TestCase):
 
     def setUp(self):
-        self.net = WaveNet(batch_size=1,
-                           dilations=[1, 2, 4, 8, 16, 32, 64, 128, 256,
-                                      1, 2, 4, 8, 16, 32, 64, 128, 256],
-                           filter_width=2,
-                           residual_channels=16,
-                           dilation_channels=16,
-                           quantization_channels=256,
-                           skip_channels=32)
+        self.net = WaveNetModel(batch_size=1,
+                                dilations=[1, 2, 4, 8, 16, 32, 64, 128, 256,
+                                           1, 2, 4, 8, 16, 32, 64, 128, 256],
+                                filter_width=2,
+                                residual_channels=16,
+                                dilation_channels=16,
+                                quantization_channels=256,
+                                skip_channels=32)
 
     # Train a net on a short clip of 3 sine waves superimposed
     # (an e-flat chord).
@@ -57,7 +56,7 @@ class TestNet(tf.test.TestCase):
         optim = optimizer.minimize(loss, var_list=trainable)
         init = tf.initialize_all_variables()
 
-        max_allowed_loss = 0.1
+        max_allowed_loss = 0.2
         loss_val = max_allowed_loss
         initial_loss = None
         with self.test_session() as sess:
@@ -65,7 +64,7 @@ class TestNet(tf.test.TestCase):
             initial_loss = sess.run(loss)
             for i in range(50):
                 loss_val, _ = sess.run([loss, optim])
-                # print "i: %d loss: %f" % (i, loss_val)
+                # print("i: %d loss: %f" % (i, loss_val))
 
         # Sanity check the initial loss was larger.
         self.assertGreater(initial_loss, max_allowed_loss)
@@ -81,15 +80,15 @@ class TestNet(tf.test.TestCase):
 class TestNetWithBiases(TestNet):
 
     def setUp(self):
-        self.net = WaveNet(batch_size=1,
-                           dilations=[1, 2, 4, 8, 16, 32, 64, 128, 256,
-                                      1, 2, 4, 8, 16, 32, 64, 128, 256],
-                           filter_width=2,
-                           residual_channels=16,
-                           dilation_channels=16,
-                           quantization_channels=256,
-                           use_biases=True,
-                           skip_channels=32)
+        self.net = WaveNetModel(batch_size=1,
+                                dilations=[1, 2, 4, 8, 16, 32, 64, 128, 256,
+                                           1, 2, 4, 8, 16, 32, 64, 128, 256],
+                                filter_width=2,
+                                residual_channels=16,
+                                dilation_channels=16,
+                                quantization_channels=256,
+                                use_biases=True,
+                                skip_channels=32)
 
 if __name__ == '__main__':
     tf.test.main()

--- a/test/test_mu_law.py
+++ b/test/test_mu_law.py
@@ -1,7 +1,7 @@
 import numpy as np
 import tensorflow as tf
 
-from wavenet_ops import mu_law_encode, mu_law_decode
+from wavenet import mu_law_encode, mu_law_decode
 
 
 # A set of mu law encode/decode functions implemented

--- a/train.py
+++ b/train.py
@@ -17,8 +17,7 @@ import time
 import tensorflow as tf
 from tensorflow.python.client import timeline
 
-from wavenet import WaveNet
-from audio_reader import AudioReader
+from wavenet import WaveNetModel, AudioReader
 
 BATCH_SIZE = 1
 DATA_DIRECTORY = './VCTK-Corpus'
@@ -185,7 +184,7 @@ def main():
         audio_batch = reader.dequeue(args.batch_size)
 
     # Create network.
-    net = WaveNet(
+    net = WaveNetModel(
         batch_size=args.batch_size,
         dilations=wavenet_params["dilations"],
         filter_width=wavenet_params["filter_width"],

--- a/wavenet/__init__.py
+++ b/wavenet/__init__.py
@@ -1,0 +1,4 @@
+from .model import WaveNetModel
+from .audio_reader import AudioReader
+from .ops import (mu_law_encode, mu_law_decode, time_to_batch,
+                  batch_to_time, causal_conv)

--- a/wavenet/audio_reader.py
+++ b/wavenet/audio_reader.py
@@ -90,9 +90,10 @@ class AudioReader(object):
                 # Remove silence
                 audio = trim_silence(audio[:, 0], self.silence_threshold)
                 if audio.size == 0:
-                    print("[!] {} was ignored as it only contains silence. \n"
-                          "    Consider decreasing trim_silence threshold, or adjust volume "
-                          "of the audio.".format(filename))
+                    print("Warning: {} was ignored as it contains only "
+                          "silence. Consider decreasing trim_silence "
+                          "threshold, or adjust volume of the audio."
+                          .format(filename))
 
                 if self.sample_size:
                     # Cut samples into fixed size pieces

--- a/wavenet/model.py
+++ b/wavenet/model.py
@@ -1,10 +1,24 @@
 import tensorflow as tf
 
-from wavenet_ops import causal_conv, mu_law_encode, create_variable, \
-                        create_bias_variable
+from .ops import causal_conv, mu_law_encode
 
 
-class WaveNet(object):
+def create_variable(name, shape):
+    '''Create a convolution filter variable with the specified name and shape,
+    and initialize it using Xavier initialition.'''
+    initializer = tf.contrib.layers.xavier_initializer_conv2d()
+    variable = tf.Variable(initializer(shape=shape), name=name)
+    return variable
+
+
+def create_bias_variable(name, shape):
+    '''Create a bias variable with the specified name and shape and initialize
+    it to zero.'''
+    initializer = tf.constant_initializer(value=0.0, dtype=tf.float32)
+    return tf.Variable(initializer(shape=shape), name)
+
+
+class WaveNetModel(object):
     '''Implements the WaveNet network for generative audio.
 
     Usage (with the architecture as in the DeepMind paper):
@@ -25,8 +39,7 @@ class WaveNet(object):
                  dilation_channels,
                  skip_channels,
                  quantization_channels=2**8,
-                 use_biases=False,
-                 fast_generation=False):
+                 use_biases=False):
         '''Initializes the WaveNet model.
 
         Args:
@@ -45,8 +58,6 @@ class WaveNet(object):
                 Default: 256 (8-bit quantization).
             use_biases: Whether to add a bias layer to each convolution.
                 Default: False.
-            fast_generation: Whether to use the fast generation architecture.
-                Default: False.
         '''
         self.batch_size = batch_size
         self.dilations = dilations
@@ -56,11 +67,85 @@ class WaveNet(object):
         self.quantization_channels = quantization_channels
         self.use_biases = use_biases
         self.skip_channels = skip_channels
-        self.fast_generation = fast_generation
 
-        if self.fast_generation and self.use_biases:
-            raise NotImplementedError(
-                'Biases not implemented for fast generation.')
+        self.variables = self._create_variables()
+
+    def _create_variables(self):
+        '''This function creates all variables used by the network.
+        This allows us to share them between multiple calls to the loss
+        function and generation function.'''
+
+        var = dict()
+
+        with tf.variable_scope('wavenet'):
+            with tf.variable_scope('causal_layer'):
+                layer = dict()
+                layer['filter'] = create_variable(
+                    'filter',
+                    [self.filter_width,
+                     self.quantization_channels,
+                     self.residual_channels])
+                var['causal_layer'] = layer
+
+            var['dilated_stack'] = list()
+            with tf.variable_scope('dilated_stack'):
+                for i, dilation in enumerate(self.dilations):
+                    with tf.variable_scope('layer{}'.format(i)):
+                        current = dict()
+                        current['filter'] = create_variable(
+                            'filter',
+                            [self.filter_width,
+                             self.residual_channels,
+                             self.dilation_channels])
+                        current['gate'] = create_variable(
+                            'gate',
+                            [self.filter_width,
+                             self.residual_channels,
+                             self.dilation_channels])
+                        current['dense'] = create_variable(
+                            'dense',
+                            [self.filter_width,
+                             self.dilation_channels,
+                             self.residual_channels])
+                        current['skip'] = create_variable(
+                            'skip',
+                            [self.filter_width,
+                             self.dilation_channels,
+                             self.skip_channels])
+                        if self.use_biases:
+                            current['filter_bias'] = create_bias_variable(
+                                'filter_bias',
+                                [self.dilation_channels])
+                            current['gate_bias'] = create_bias_variable(
+                                'gate_bias',
+                                [self.dilation_channels])
+                            current['dense_bias'] = create_bias_variable(
+                                'dense_bias',
+                                [self.residual_channels])
+                            current['skip_bias'] = create_bias_variable(
+                                'slip_bias',
+                                [self.skip_channels])
+
+                        var['dilated_stack'].append(current)
+
+            with tf.variable_scope('postprocessing'):
+                current = dict()
+                current['postprocess1'] = create_variable(
+                    'postprocess1',
+                    [1, self.skip_channels, self.skip_channels])
+                current['postprocess2'] = create_variable(
+                    'postprocess2',
+                    [1, self.skip_channels, self.quantization_channels])
+                if self.use_biases:
+                    current['postprocess1_bias'] = create_bias_variable(
+                        'postprocess1_bias',
+                        [self.skip_channels])
+                    current['postprocess2_bias'] = create_bias_variable(
+                        'postprocess2_bias',
+                        [self.quantization_channels])
+                var['postprocessing'] = current
+
+        return var
 
     def _create_causal_layer(self, input_batch, in_channels, out_channels):
         '''Creates a single causal convolution layer.
@@ -68,9 +153,7 @@ class WaveNet(object):
         The layer can change the number of channels.
         '''
         with tf.name_scope('causal_layer'):
-            weights_filter = create_variable("filter", [self.filter_width,
-                                                        in_channels,
-                                                        out_channels])
+            weights_filter = self.variables['causal_layer']['filter']
             return causal_conv(input_batch, weights_filter, 1)
 
     def _create_dilation_layer(self, input_batch, layer_index, dilation,
@@ -81,7 +164,7 @@ class WaveNet(object):
         and to a skip connection:
 
                |-> [gate]   -|        |-> 1x1 conv -> skip output
-               |             |-> (*) -| 
+               |             |-> (*) -|
         input -|-> [filter] -|        |-> 1x1 conv -|
                |                                    |-> (+) -> dense output
                |------------------------------------|
@@ -89,43 +172,37 @@ class WaveNet(object):
         Where `[gate]` and `[filter]` are causal convolutions with a
         non-linear activation at the output.
         '''
-        weights_filter = create_variable("filter", [self.filter_width,
-                                                    in_channels,
-                                                    dilation_channels])
-        weights_gate = create_variable("gate", [self.filter_width,
-                                                in_channels,
-                                                dilation_channels])
+        variables = self.variables['dilated_stack'][layer_index]
+
+        weights_filter = variables['filter']
+        weights_gate = variables['gate']
 
         conv_filter = causal_conv(input_batch, weights_filter, dilation)
         conv_gate = causal_conv(input_batch, weights_gate, dilation)
 
         if self.use_biases:
-            biases_filter = create_bias_variable("filter_biases",
-                                                 [dilation_channels])
-            biases_gate = create_bias_variable("filter_biases",
-                                               [dilation_channels])
-            conv_filter = tf.add(conv_filter, biases_filter)
-            conv_gate = tf.add(conv_gate, biases_gate)
+            filter_bias = variables['filter_bias']
+            gate_bias = variables['gate_bias']
+            conv_filter = tf.add(conv_filter, filter_bias)
+            conv_gate = tf.add(conv_gate, gate_bias)
 
         out = tf.tanh(conv_filter) * tf.sigmoid(conv_gate)
 
-        # The 1x1 conv to produce the dense contribution.
-        weights_dense = create_variable("dense", [1, dilation_channels,
-                                                     in_channels])
+        # The 1x1 conv to produce the residual output
+        weights_dense = variables['dense']
         transformed = tf.nn.conv1d(
             out, weights_dense, stride=1, padding="SAME", name="dense")
 
-        # The 1x1 conv to produce the skip contribution.
-        weights_skip = create_variable("skip", [1, dilation_channels,
-                                                skip_channels])
+        # The 1x1 conv to produce the skip output
+        weights_skip = variables['skip']
         skip_contribution = tf.nn.conv1d(
             out, weights_skip, stride=1, padding="SAME", name="skip")
 
         if self.use_biases:
-            biases_dense = create_bias_variable("dense_biases", [in_channels])
-            transformed = tf.add(transformed, biases_dense)
-            biases_skip = create_bias_variable("skip_biases", [skip_channels])
-            skip_contribution = tf.add(skip_contribution, biases_skip)
+            dense_bias = variables['dense_bias']
+            skip_bias = variables['skip_bias']
+            transformed = tf.add(transformed, dense_bias)
+            skip_contribution = tf.add(skip_contribution, skip_bias)
 
         layer = 'layer{}'.format(layer_index)
         tf.histogram_summary(layer + '_filter', weights_filter)
@@ -133,72 +210,54 @@ class WaveNet(object):
         tf.histogram_summary(layer + '_dense', weights_dense)
         tf.histogram_summary(layer + '_skip', weights_skip)
         if self.use_biases:
-            tf.histogram_summary(layer + '_biases_filter', biases_filter)
-            tf.histogram_summary(layer + '_biases_gate', biases_gate)
-            tf.histogram_summary(layer + '_biases_dense', biases_dense)
-            tf.histogram_summary(layer + '_biases_skip', biases_skip)
+            tf.histogram_summary(layer + '_biases_filter', filter_bias)
+            tf.histogram_summary(layer + '_biases_gate', gate_bias)
+            tf.histogram_summary(layer + '_biases_dense', dense_bias)
+            tf.histogram_summary(layer + '_biases_skip', skip_bias)
 
         return skip_contribution, input_batch + transformed
 
-    def _apply_weights(self, input_batch, state_batch, weights):
-        weights_recurrent = weights[0, :, :]
-        weights_embedding = weights[1, :, :]
-
-        output = (tf.matmul(input_batch, weights_embedding) + tf.matmul(
-            state_batch, weights_recurrent))
+    def _generator_conv(self, input_batch, state_batch, weights):
+        '''Perform convolution for a single convolutional processing step.'''
+        # TODO generalize to filter_width > 2
+        past_weights = weights[0, :, :]
+        curr_weights = weights[1, :, :]
+        output = tf.matmul(state_batch, past_weights) + tf.matmul(
+            input_batch, curr_weights)
         return output
 
     def _generator_causal_layer(self, input_batch, state_batch, in_channels,
                                 out_channels):
         with tf.name_scope('causal_layer'):
-            weights_filter = tf.Variable(
-                tf.truncated_normal(
-                    [self.filter_width, in_channels, out_channels],
-                    stddev=0.2),
-                    name="filter")
-
-            output = self._apply_weights(input_batch, state_batch,
-                                         weights_filter)
+            weights_filter = self.variables['causal_layer']['filter']
+            output = self._generator_conv(
+                input_batch, state_batch, weights_filter)
         return output
 
     def _generator_dilation_layer(self, input_batch, state_batch, layer_index,
                                   dilation, in_channels, dilation_channels,
                                   skip_channels):
-        weights_filter = tf.Variable(
-            tf.truncated_normal(
-                [self.filter_width, in_channels, dilation_channels],
-                stddev=0.2),
-                name="filter")
-        weights_gate = tf.Variable(
-            tf.truncated_normal(
-                [self.filter_width, in_channels, dilation_channels],
-                stddev=0.2),
-                name="gate")
+        variables = self.variables['dilated_stack'][layer_index]
 
-        output_filter = self._apply_weights(input_batch, state_batch,
-                                            weights_filter)
-        output_gate = self._apply_weights(input_batch, state_batch,
-                                          weights_gate)
+        weights_filter = variables['filter']
+        weights_gate = variables['gate']
+        output_filter = self._generator_conv(
+            input_batch, state_batch, weights_filter)
+        output_gate = self._generator_conv(
+            input_batch, state_batch, weights_gate)
 
         out = tf.tanh(output_filter) * tf.sigmoid(output_gate)
 
-        weights_dense = tf.Variable(
-            tf.truncated_normal(
-                [1, dilation_channels, in_channels], stddev=0.2), name="dense")
+        weights_dense = variables['dense']
         transformed = tf.matmul(out, weights_dense[0, :, :])
 
-        weights_skip = tf.Variable(
-            tf.truncated_normal(
-                [1, dilation_channels, skip_channels], stddev=0.1),
-                name="skip")
+        weights_skip = variables['skip']
         skip_contribution = tf.matmul(out, weights_skip[0, :, :])
-
-        layer = 'layer{}'.format(layer_index)
 
         return skip_contribution, input_batch + transformed
 
     def _create_network(self, input_batch):
-        '''Creates a WaveNet network.'''
+        '''Construct the WaveNet network.'''
         outputs = []
         current_layer = input_batch
 
@@ -219,15 +278,11 @@ class WaveNet(object):
         with tf.name_scope('postprocessing'):
             # Perform (+) -> ReLU -> 1x1 conv -> ReLU -> 1x1 conv to
             # postprocess the output.
-            w1 = create_variable("postprocess1", [1, self.skip_channels,
-                                                  self.skip_channels])
-            w2 = create_variable("postprocess2", [1, self.skip_channels,
-                                                  self.quantization_channels])
+            w1 = self.variables['postprocessing']['postprocess1']
+            w2 = self.variables['postprocessing']['postprocess2']
             if self.use_biases:
-                b1 = create_bias_variable("postprocess1_bias",
-                                          [self.skip_channels])
-                b2 = create_bias_variable("postprocess2_bias",
-                                          [self.quantization_channels])
+                b1 = self.variables['postprocessing']['postprocess1_bias']
+                b2 = self.variables['postprocessing']['postprocess2_bias']
 
             tf.histogram_summary('postprocess1_weights', w1)
             tf.histogram_summary('postprocess2_weights', w2)
@@ -250,6 +305,7 @@ class WaveNet(object):
         return conv2
 
     def _create_generator(self, input_batch):
+        '''Construct an efficient incremental generator.'''
         init_ops = []
         push_ops = []
         outputs = []
@@ -300,17 +356,8 @@ class WaveNet(object):
         with tf.name_scope('postprocessing'):
             # Perform (+) -> ReLU -> 1x1 conv -> ReLU -> 1x1 conv to
             # postprocess the output.
-            w1 = tf.Variable(
-                tf.truncated_normal(
-                    [1, self.skip_channels, self.skip_channels],
-                    stddev=0.3),
-                    name="postprocess1")
-            w2 = tf.Variable(
-                tf.truncated_normal(
-                    [1, self.skip_channels, self.quantization_channels],
-                    stddev=0.3),
-                    name="postprocess2")
- 
+            w1 = self.variables['postprocessing']['postprocess1']
+            w2 = self.variables['postprocessing']['postprocess2']
             # We skip connections from the outputs of each layer, adding them
             # all up here.
             total = sum(outputs)
@@ -333,28 +380,50 @@ class WaveNet(object):
                 input_batch,
                 depth=self.quantization_channels,
                 dtype=tf.float32)
-            if self.fast_generation:
-                shape = [self.batch_size, self.quantization_channels]
-            else:
-                shape = [self.batch_size, -1, self.quantization_channels]
+            shape = [self.batch_size, -1, self.quantization_channels]
             encoded = tf.reshape(encoded, shape)
         return encoded
 
     def predict_proba(self, waveform, name='wavenet'):
-        '''Computes the probability distribution of the next sample.'''
+        '''Computes the probability distribution of the next sample based on
+        all samples in the input waveform.
+        If you want to generate audio by feeding the output of the network back
+        as an input, see predict_proba_incremental for a faster alternative.'''
         with tf.name_scope(name):
             encoded = self._one_hot(waveform)
-            if self.fast_generation:
-                if self.use_biases:
-                    raise RuntimeError("Fast generation does not support" \
-                                       " biases.")
-                raw_output = self._create_generator(encoded)
-            else:
-                raw_output = self._create_network(encoded)
+            raw_output = self._create_network(encoded)
             out = tf.reshape(raw_output, [-1, self.quantization_channels])
-            proba = tf.nn.softmax(tf.cast(out, tf.float64))
-            last = tf.slice(proba, [tf.shape(proba)[0] - 1, 0],
-                            [1, self.quantization_channels])
+            # Cast to float64 to avoid bug in TensorFlow
+            proba = tf.cast(
+                tf.nn.softmax(tf.cast(out, tf.float64)), tf.float32)
+            last = tf.slice(
+                proba,
+                [tf.shape(proba)[0] - 1, 0],
+                [1, self.quantization_channels])
+            return tf.reshape(last, [-1])
+
+    def predict_proba_incremental(self, waveform, name='wavenet'):
+        '''Computes the probability distribution of the next sample
+        incrementally, based on a single sample and all previously passed
+        samples.'''
+        if self.filter_width > 2:
+            raise NotImplementedError("Incremental generation does not "
+                                      "support filter_width > 2.")
+        if self.use_biases:
+            raise NotImplementedError("Incremental generation does not "
+                                      "support biases.")
+        with tf.name_scope(name):
+
+            encoded = tf.one_hot(waveform, self.quantization_channels)
+            encoded = tf.reshape(encoded, [-1, self.quantization_channels])
+            raw_output = self._create_generator(encoded)
+            out = tf.reshape(raw_output, [-1, self.quantization_channels])
+            proba = tf.cast(
+                tf.nn.softmax(tf.cast(out, tf.float64)), tf.float32)
+            last = tf.slice(
+                proba,
+                [tf.shape(proba)[0] - 1, 0],
+                [1, self.quantization_channels])
             return tf.reshape(last, [-1])
 
     def loss(self, input_batch, name='wavenet'):
@@ -363,10 +432,15 @@ class WaveNet(object):
         The variables are all scoped to the given name.
         '''
         with tf.name_scope(name):
+            # We mu-law encode and quantize the input audioform,
+            # and use this as input for the first layer.
             input_batch = mu_law_encode(input_batch,
                                         self.quantization_channels)
+            network_input = tf.cast(input_batch, tf.float32)
             encoded = self._one_hot(input_batch)
-            raw_output = self._create_network(encoded)
+            input_batch = tf.reshape(
+                encoded, [self.batch_size, -1, self.quantization_channels])
+            raw_output = self._create_network(input_batch)
 
             with tf.name_scope('loss'):
                 # Shift original input left by one sample, which means that

--- a/wavenet/model.py
+++ b/wavenet/model.py
@@ -26,8 +26,8 @@ class WaveNetModel(object):
         filter_width = 2  # Convolutions just use 2 samples.
         residual_channels = 16  # Not specified in the paper.
         dilation_channels = 32  # Not specified in the paper.
-        net = WaveNet(batch_size, dilations, filter_width,
-                      residual_channels, dilation_channel)
+        net = WaveNetModel(batch_size, dilations, filter_width,
+                           residual_channels, dilation_channel)
         loss = net.loss(input_batch)
     '''
 
@@ -450,11 +450,8 @@ class WaveNetModel(object):
             # and use this as input for the first layer.
             input_batch = mu_law_encode(input_batch,
                                         self.quantization_channels)
-            network_input = tf.cast(input_batch, tf.float32)
             encoded = self._one_hot(input_batch)
-            input_batch = tf.reshape(
-                encoded, [self.batch_size, -1, self.quantization_channels])
-            raw_output = self._create_network(input_batch)
+            raw_output = self._create_network(encoded)
 
             with tf.name_scope('loss'):
                 # Shift original input left by one sample, which means that

--- a/wavenet/model.py
+++ b/wavenet/model.py
@@ -104,12 +104,12 @@ class WaveNetModel(object):
                              self.dilation_channels])
                         current['dense'] = create_variable(
                             'dense',
-                            [self.filter_width,
+                            [1,
                              self.dilation_channels,
                              self.residual_channels])
                         current['skip'] = create_variable(
                             'skip',
-                            [self.filter_width,
+                            [1,
                              self.dilation_channels,
                              self.skip_channels])
                         if self.use_biases:

--- a/wavenet/model.py
+++ b/wavenet/model.py
@@ -199,10 +199,8 @@ class WaveNetModel(object):
             out, weights_skip, stride=1, padding="SAME", name="skip")
 
         if self.use_biases:
-            dense_bias = variables['dense_bias']
-            skip_bias = variables['skip_bias']
-            transformed = tf.add(transformed, dense_bias)
-            skip_contribution = tf.add(skip_contribution, skip_bias)
+            transformed = transformed + variables['dense_bias']
+            skip_contribution = skip_contribution + variables['skip_bias']
 
         layer = 'layer{}'.format(layer_index)
         tf.histogram_summary(layer + '_filter', weights_filter)

--- a/wavenet/model.py
+++ b/wavenet/model.py
@@ -199,8 +199,10 @@ class WaveNetModel(object):
             out, weights_skip, stride=1, padding="SAME", name="skip")
 
         if self.use_biases:
-            transformed = transformed + variables['dense_bias']
-            skip_contribution = skip_contribution + variables['skip_bias']
+            dense_bias = variables['dense_bias']
+            skip_bias = variables['skip_bias']
+            transformed = transformed + dense_bias
+            skip_contribution = skip_contribution + skip_bias
 
         layer = 'layer{}'.format(layer_index)
         tf.histogram_summary(layer + '_filter', weights_filter)

--- a/wavenet/ops.py
+++ b/wavenet/ops.py
@@ -3,23 +3,6 @@ from __future__ import division
 import tensorflow as tf
 
 
-# Create a convolution filter variable with the specified name and shape,
-# and initialize it using xavier initialization.
-def create_variable(name, shape):
-    #    initializer = tf.contrib.layers.xavier_initializer_conv2d()
-    #    variable = tf.get_variable(name, shape=shape, initializer=initializer)
-    initializer = tf.contrib.layers.xavier_initializer_conv2d()
-    variable = tf.Variable(initializer(shape=shape), name=name)
-    return variable
-
-
-# Create a bias variable with the specified name and shape and initialize
-# it to zero.
-def create_bias_variable(name, shape):
-    initializer = tf.constant_initializer(value=0.0, dtype=tf.float32)
-    return tf.Variable(initializer(shape=shape), name)
-
-
 def time_to_batch(value, dilation, name=None):
     with tf.name_scope('time_to_batch'):
         shape = tf.shape(value)


### PR DESCRIPTION
I've rewritten some of the code today to make it easier to test and extend in the future.
Among other things, I've
 - Moved the code files into a `wavenet` package
 - Defined all variables in `Wavenet` up front so that they can be shared between training and generation methods
 - Renamed `WaveNet` to `WaveNetModel` because I want to introduce another class `WaveNet` that manages all the TensorFlow stuff around `WaveNetModel` so that the `train.py` and `generate.py` scripts should become very simple.
 - Added tests for generation (including a passing test that compares the old and new generation methods)
 - Fixed a bug in how we handled the boolean argument in `generate.py`