### PR TITLE
Fix --fast_generation flag in generation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,14 +105,13 @@ Passing `--save_every` in addition to `--wav_out_path` will save the in-progress
 python generate.py --wav_out_path=generated.wav --save_every 2000 --samples 16000 model.ckpt-1000
 ```
 
-For fast generation:
+Fast generation is enabled by default. It uses the implementation from the [Fast Wavenet](https://github.com/tomlepaine/fast-wavenet) repository. You can follow the link for an explanation of how it works. This reduces the time needed to generate samples to a few minutes.
+
+To disable fast generation:
 ```
-python generate.py --samples 16000 model.ckpt-1000 --fast_generation=true
+python generate.py --samples 16000 model.ckpt-1000 --disable_fast_generation
 ```
 
-The fast generation algorithm uses the implementation from the [Fast Wavenet](https://github.com/tomlepaine/fast-wavenet) repository.
-You can follow the link for an explanation of how it works.
-This reduces the time needed to generate samples to a few minutes.
 
 ## Missing features
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Fast generation is enabled by default. It uses the implementation from the [Fast
 
 To disable fast generation:
 ```
-python generate.py --samples 16000 model.ckpt-1000 --disable_fast_generation
+python generate.py --samples 16000 model.ckpt-1000 --fast_generation=false
 ```
 
 

--- a/generate.py
+++ b/generate.py
@@ -20,6 +20,12 @@ SAVE_EVERY = None
 
 
 def get_arguments():
+    def _str_to_bool(s):
+        """Convert string to bool (in argparse context)."""
+        if s.lower() not in ['true', 'false']:
+            raise ValueError('Argument needs to be a boolean, got {}'.format(s))
+        return {'true': True, 'false': False}[s.lower()]
+
     parser = argparse.ArgumentParser(description='WaveNet generation script')
     parser.add_argument(
         'checkpoint', type=str, help='Which model checkpoint to generate from')
@@ -55,12 +61,11 @@ def get_arguments():
         type=int,
         default=SAVE_EVERY,
         help='How many samples before saving in-progress wav')
-    parser.set_defaults(fast_generation=True)
     parser.add_argument(
-        '--disable_fast_generation',
-        dest='fast_generation',
-        action='store_false',
-        help='Disable fast generation')
+        '--fast_generation',
+        default=True,
+        type=_str_to_bool,
+        help='Use fast generation')
     parser.add_argument(
         '--wav_seed',
         type=str,

--- a/generate.py
+++ b/generate.py
@@ -55,11 +55,12 @@ def get_arguments():
         type=int,
         default=SAVE_EVERY,
         help='How many samples before saving in-progress wav')
+    parser.set_defaults(fast_generation=True)
     parser.add_argument(
-        '--fast_generation',
-        type=bool,
-        default=True,
-        help='Use fast generation')
+        '--disable_fast_generation',
+        dest='fast_generation',
+        action='store_false',
+        help='Disable fast generation')
     parser.add_argument(
         '--wav_seed',
         type=str,


### PR DESCRIPTION
The generation script's `fast_generation` flag wasn't working as intended: even when specified on the command line as `False`, the flag was being sent to the model as `True`, due to an unintended behavior of the `argparse` library, [documented here](http://stackoverflow.com/questions/15008758/parsing-boolean-values-with-argparse).

In this patch, I kept the feature's default `true`, as you had it, and added a `disable_fast_generation` flag (which takes no further arguments).

I also updated the README.

Thanks!