### PR TITLE
Minor tweaks in generate.py

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -181,7 +181,8 @@ def main():
         current_sample_timestamp = datetime.now()
         time_since_print = current_sample_timestamp - last_sample_timestamp
         if time_since_print.total_seconds() > 1.:
-            print('Sample {:3<d}/{:3<d}'.format(step + 1, args.samples))
+            print('Sample {:3<d}/{:3<d}'.format(step + 1, args.samples),
+                  end='\r')
             last_sample_timestamp = current_sample_timestamp
 
         # If we have partial writing, save the result so far.
@@ -190,16 +191,20 @@ def main():
             out = sess.run(decode, feed_dict={samples: waveform})
             write_wav(out, wavenet_params['sample_rate'], args.wav_out_path)
 
+    # Introduce a newline to clear the carriage return from the progress.
+    print()
+
+    # Save the result as an audio summary.
     datestring = str(datetime.now()).replace(' ', 'T')
     writer = tf.train.SummaryWriter(
         os.path.join(logdir, 'generation', datestring))
     tf.audio_summary('generated', decode, wavenet_params['sample_rate'])
     summaries = tf.merge_all_summaries()
-
     summary_out = sess.run(summaries,
                            feed_dict={samples: np.reshape(waveform, [-1, 1])})
     writer.add_summary(summary_out)
 
+    # Save the result as a wav file.
     if args.wav_out_path:
         out = sess.run(decode, feed_dict={samples: waveform})
         write_wav(out, wavenet_params['sample_rate'], args.wav_out_path)

--- a/generate.py
+++ b/generate.py
@@ -94,7 +94,8 @@ def create_seed(filename,
 
 def main():
     args = get_arguments()
-    logdir = os.path.join(args.logdir, 'train', str(datetime.now()))
+    started_datestring = "{0:%Y-%m-%dT%H-%M-%S}".format(datetime.now())
+    logdir = os.path.join(args.logdir, 'generate', started_datestring)
     with open(args.wavenet_params, 'r') as config_file:
         wavenet_params = json.load(config_file)
 
@@ -157,6 +158,7 @@ def main():
             sess.run(outputs, feed_dict={samples: x})
         print('Done.')
 
+    last_sample_timestamp = datetime.now()
     for step in range(args.samples):
         if args.fast_generation:
             outputs = [next_sample]
@@ -169,16 +171,22 @@ def main():
                 window = waveform
             outputs = [next_sample]
 
+        # Run the WaveNet to predict the next sample.
         prediction = sess.run(outputs, feed_dict={samples: window})[0]
         sample = np.random.choice(
             np.arange(quantization_channels), p=prediction)
         waveform.append(sample)
-        print('Sample {:3<d}/{:3<d}: {}'
-              .format(step + 1, args.samples, sample))
 
+        # Show progress only once per second.
+        current_sample_timestamp = datetime.now()
+        time_since_print = current_sample_timestamp - last_sample_timestamp
+        if time_since_print.total_seconds() > 1.:
+            print('Sample {:3<d}/{:3<d}'.format(step + 1, args.samples))
+            last_sample_timestamp = current_sample_timestamp
+
+        # If we have partial writing, save the result so far.
         if (args.wav_out_path and args.save_every and
                 (step + 1) % args.save_every == 0):
-
             out = sess.run(decode, feed_dict={samples: waveform})
             write_wav(out, wavenet_params['sample_rate'], args.wav_out_path)
 
@@ -189,9 +197,7 @@ def main():
     summaries = tf.merge_all_summaries()
 
     summary_out = sess.run(summaries,
-                           feed_dict={
-                               samples: np.reshape(waveform, [-1, 1])
-                           })
+                           feed_dict={samples: np.reshape(waveform, [-1, 1])})
     writer.add_summary(summary_out)
 
     if args.wav_out_path:

--- a/train.py
+++ b/train.py
@@ -72,7 +72,7 @@ def get_arguments():
                         'Disabled by default')
     parser.add_argument('--silence_threshold', type=float,
                         default=SILENCE_THRESHOLD,
-                        help='Volume threshold below which to trim the start'
+                        help='Volume threshold below which to trim the start '
                         'and the end from the training set samples.')
     return parser.parse_args()
 

--- a/train.py
+++ b/train.py
@@ -70,8 +70,10 @@ def get_arguments():
                         default=L2_REGULARIZATION_STRENGTH,
                         help='Coefficient in the L2 regularization. '
                         'Disabled by default')
-    parser.add_argument('--silence_threshold', type=float, default=SILENCE_THRESHOLD,
-                        help='Volume threshold below which to cut from training set')
+    parser.add_argument('--silence_threshold', type=float,
+                        default=SILENCE_THRESHOLD,
+                        help='Volume threshold below which to trim the start'
+                        'and the end from the training set samples.')
     return parser.parse_args()
 
 


### PR DESCRIPTION
- Only log progress once per second while generating.
- Use the same datestring as train.py
- Save logs in `generate`, not `train`.
- Minor style nits.