### PR TITLE
Add scalar input

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -112,7 +112,9 @@ def main():
         dilation_channels=wavenet_params['dilation_channels'],
         quantization_channels=wavenet_params['quantization_channels'],
         skip_channels=wavenet_params['skip_channels'],
-        use_biases=wavenet_params['use_biases'])
+        use_biases=wavenet_params['use_biases'],
+        scalar_input=wavenet_params['scalar_input'],
+        initial_filter_width=wavenet_params['initial_filter_width'])
 
     samples = tf.placeholder(tf.int32)
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -90,6 +90,7 @@ class TestNetWithBiases(TestNet):
                                 use_biases=True,
                                 skip_channels=32)
 
+
 class TestNetWithScalarInput(TestNet):
 
     def setUp(self):

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -7,34 +7,38 @@ import tensorflow as tf
 
 from wavenet import WaveNetModel, time_to_batch, batch_to_time, causal_conv
 
+SAMPLE_RATE_HZ = 2000.0  # Hz
+TRAIN_ITERATIONS = 400
+LEARN_RATE = 0.02
+SAMPLE_DURATION = 0.2  # Seconds
+MOMENTUM = 0.9
+
 
 def MakeSineWaves():
     """Creates a time-series of audio amplitudes corresponding to 3
     superimposed sine waves."""
-    sample_rate = 1.0 / 16000.0
-    # The period of the sine wave is the inverse of the frequency in Hz.
-    p1 = 1.0 / 155.56  # E-flat
-    p2 = 1.0 / 196.00  # G
-    p3 = 1.0 / 233.08  # B-flat
-    # The duration is 100 milliseconds.
-    times = np.arange(0.0, 0.10, sample_rate)
+    # Frequencies of the sine waves in Hz.
+    f1 = 155.56  # E-flat
+    f2 = 196.00  # G
+    f3 = 233.08  # B-flat
+    sample_period = 1.0/SAMPLE_RATE_HZ
+    times = np.arange(0.0, SAMPLE_DURATION, sample_period)
 
-    amplitudes = (np.sin(times * 2.0 * np.pi / p1) / 3.0 +
-                  np.sin(times * 2.0 * np.pi / p2) / 3.0 +
-                  np.sin(times * 2.0 * np.pi / p3) / 3.0)
+    amplitudes = (np.sin(times * 2.0 * np.pi * f1) / 3.0 +
+                  np.cos(times * 2.0 * np.pi * f2) / 3.0 +
+                  np.sin(times * 2.0 * np.pi * f3) / 3.0)
 
     return amplitudes
 
 
 class TestNet(tf.test.TestCase):
-
     def setUp(self):
         self.net = WaveNetModel(batch_size=1,
                                 dilations=[1, 2, 4, 8, 16, 32, 64, 128, 256,
                                            1, 2, 4, 8, 16, 32, 64, 128, 256],
                                 filter_width=2,
-                                residual_channels=16,
-                                dilation_channels=16,
+                                residual_channels=32,
+                                dilation_channels=32,
                                 quantization_channels=256,
                                 skip_channels=32)
 
@@ -51,7 +55,8 @@ class TestNet(tf.test.TestCase):
 
         audio_tensor = tf.convert_to_tensor(audio, dtype=tf.float32)
         loss = self.net.loss(audio_tensor)
-        optimizer = tf.train.AdamOptimizer(learning_rate=0.02)
+        optimizer = tf.train.MomentumOptimizer(learning_rate=LEARN_RATE,
+                                               momentum=MOMENTUM)
         trainable = tf.trainable_variables()
         optim = optimizer.minimize(loss, var_list=trainable)
         init = tf.initialize_all_variables()
@@ -62,9 +67,10 @@ class TestNet(tf.test.TestCase):
         with self.test_session() as sess:
             sess.run(init)
             initial_loss = sess.run(loss)
-            for i in range(50):
+            for i in range(TRAIN_ITERATIONS):
                 loss_val, _ = sess.run([loss, optim])
-                # print("i: %d loss: %f" % (i, loss_val))
+                # if i % 10 == 0:
+                #     print("i: %d loss: %f" % (i, loss_val))
 
         # Sanity check the initial loss was larger.
         self.assertGreater(initial_loss, max_allowed_loss)
@@ -84,8 +90,8 @@ class TestNetWithBiases(TestNet):
                                 dilations=[1, 2, 4, 8, 16, 32, 64, 128, 256,
                                            1, 2, 4, 8, 16, 32, 64, 128, 256],
                                 filter_width=2,
-                                residual_channels=16,
-                                dilation_channels=16,
+                                residual_channels=32,
+                                dilation_channels=32,
                                 quantization_channels=256,
                                 use_biases=True,
                                 skip_channels=32)
@@ -98,13 +104,13 @@ class TestNetWithScalarInput(TestNet):
                                 dilations=[1, 2, 4, 8, 16, 32, 64, 128, 256,
                                            1, 2, 4, 8, 16, 32, 64, 128, 256],
                                 filter_width=2,
-                                residual_channels=16,
-                                dilation_channels=16,
+                                residual_channels=32,
+                                dilation_channels=32,
                                 quantization_channels=256,
-                                use_biases=False,
+                                use_biases=True,
                                 skip_channels=32,
                                 scalar_input=True,
-                                initial_filter_width=16)
+                                initial_filter_width=32)
 
 if __name__ == '__main__':
     tf.test.main()

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -90,5 +90,20 @@ class TestNetWithBiases(TestNet):
                                 use_biases=True,
                                 skip_channels=32)
 
+class TestNetWithScalarInput(TestNet):
+
+    def setUp(self):
+        self.net = WaveNetModel(batch_size=1,
+                                dilations=[1, 2, 4, 8, 16, 32, 64, 128, 256,
+                                           1, 2, 4, 8, 16, 32, 64, 128, 256],
+                                filter_width=2,
+                                residual_channels=16,
+                                dilation_channels=16,
+                                quantization_channels=256,
+                                use_biases=False,
+                                skip_channels=32,
+                                scalar_input=True,
+                                initial_filter_width=16)
+
 if __name__ == '__main__':
     tf.test.main()

--- a/train.py
+++ b/train.py
@@ -202,7 +202,9 @@ def main():
         dilation_channels=wavenet_params["dilation_channels"],
         skip_channels=wavenet_params["skip_channels"],
         quantization_channels=wavenet_params["quantization_channels"],
-        use_biases=wavenet_params["use_biases"])
+        use_biases=wavenet_params["use_biases"],
+        scalar_input=wavenet_params["scalar_input"],
+        initial_filter_width=wavenet_params["initial_filter_width"])
     if args.l2_regularization_strength == 0:
         args.l2_regularization_strength = None
     loss = net.loss(audio_batch, args.l2_regularization_strength)

--- a/wavenet_params.json
+++ b/wavenet_params.json
@@ -1,11 +1,15 @@
 {
     "filter_width": 2,
     "sample_rate": 16000,
-    "dilations": [1, 2, 4, 8, 16, 32, 64, 128, 256,
-                  1, 2, 4, 8, 16, 32, 64, 128, 256],
+    "dilations": [1, 2, 4, 8, 16, 32, 64, 128, 256, 512,
+                  1, 2, 4, 8, 16, 32, 64, 128, 256, 512,
+                  1, 2, 4, 8, 16, 32, 64, 128, 256, 512,
+                  1, 2, 4, 8, 16, 32, 64, 128, 256, 512],
     "residual_channels": 32,
-    "dilation_channels":16,
+    "dilation_channels":32,
     "quantization_channels": 256,
-    "skip_channels": 256,
-    "use_biases": false
+    "skip_channels": 512,
+    "use_biases": false,
+    "scalar_input": true,
+    "initial_filter_width": 32
 }

--- a/wavenet_params.json
+++ b/wavenet_params.json
@@ -1,15 +1,13 @@
 {
     "filter_width": 2,
     "sample_rate": 16000,
-    "dilations": [1, 2, 4, 8, 16, 32, 64, 128, 256, 512,
-                  1, 2, 4, 8, 16, 32, 64, 128, 256, 512,
-                  1, 2, 4, 8, 16, 32, 64, 128, 256, 512,
-                  1, 2, 4, 8, 16, 32, 64, 128, 256, 512],
+    "dilations": [1, 2, 4, 8, 16, 32, 64, 128, 256,
+                  1, 2, 4, 8, 16, 32, 64, 128, 256],
     "residual_channels": 32,
-    "dilation_channels":32,
+    "dilation_channels": 16,
     "quantization_channels": 256,
-    "skip_channels": 512,
+    "skip_channels": 256,
     "use_biases": false,
-    "scalar_input": true,
+    "scalar_input": false,
     "initial_filter_width": 32
 }


### PR DESCRIPTION
This adds a `scalar_input` option to the network parameters, as well as an `initial_filter_width` that specifies the size of the filter in the first causal convolution.

Unfortunately, this currently ends up failing the corresponding test case in `test/test_model.py`, because the loss takes way too long to drop when using the scalar input.
Maybe there's a mistake in how I've implemented this, so it might be worth having a closer look.