### PR TITLE
Default the silence trimming threshold in exactly 1 place

### DIFF
--- a/train.py
+++ b/train.py
@@ -30,6 +30,7 @@ STARTED_DATESTRING = "{0:%Y-%m-%dT%H-%M-%S}".format(datetime.now())
 SAMPLE_SIZE = 100000
 L2_REGULARIZATION_STRENGTH = 0
 SILENCE_THRESHOLD = 0.3
+EPSILON = 0.001
 
 
 def get_arguments():
@@ -185,6 +186,10 @@ def main():
 
     # Load raw waveform from VCTK corpus.
     with tf.name_scope('create_inputs'):
+        # Allow silence trimming to be skipped by specifying a threshold near
+        # zero.
+        silence_threshold = args.silence_threshold if args.silence_threshold > \
+                                                      EPSILON else None
         reader = AudioReader(
             args.data_dir,
             coord,

--- a/wavenet/audio_reader.py
+++ b/wavenet/audio_reader.py
@@ -41,8 +41,6 @@ def load_vctk_audio(directory, sample_rate):
 
 def trim_silence(audio, threshold):
     '''Removes silence at the beginning and end of a sample.'''
-    if threshold is None:
-        raise ValueError('Missing silence trimming threshold.')
     energy = librosa.feature.rmse(audio)
     frames = np.nonzero(energy > threshold)
     indices = librosa.core.frames_to_samples(frames)[1]
@@ -89,13 +87,14 @@ class AudioReader(object):
                     self.stop_threads()
                     stop = True
                     break
-                # Remove silence
-                audio = trim_silence(audio[:, 0], self.silence_threshold)
-                if audio.size == 0:
-                    print("Warning: {} was ignored as it contains only "
-                          "silence. Consider decreasing trim_silence "
-                          "threshold, or adjust volume of the audio."
-                          .format(filename))
+                if self.silence_threshold is not None:
+                    # Remove silence
+                    audio = trim_silence(audio[:, 0], self.silence_threshold)
+                    if audio.size == 0:
+                        print("Warning: {} was ignored as it contains only "
+                              "silence. Consider decreasing trim_silence "
+                              "threshold, or adjust volume of the audio."
+                              .format(filename))
 
                 if self.sample_size:
                     # Cut samples into fixed size pieces

--- a/wavenet/audio_reader.py
+++ b/wavenet/audio_reader.py
@@ -39,8 +39,10 @@ def load_vctk_audio(directory, sample_rate):
         yield audio, speaker_id
 
 
-def trim_silence(audio, threshold=0.3):
+def trim_silence(audio, threshold):
     '''Removes silence at the beginning and end of a sample.'''
+    if threshold is None:
+        raise ValueError('Missing silence trimming threshold.')
     energy = librosa.feature.rmse(audio)
     frames = np.nonzero(energy > threshold)
     indices = librosa.core.frames_to_samples(frames)[1]
@@ -58,7 +60,7 @@ class AudioReader(object):
                  coord,
                  sample_rate,
                  sample_size=None,
-                 silence_threshold=0.3,
+                 silence_threshold=None,
                  queue_size=256):
         self.audio_dir = audio_dir
         self.sample_rate = sample_rate


### PR DESCRIPTION
I thought I was changing the silence trimming threshold, but it appears in more than one place in the code. I was changing the wrong one. Only the default specified by the command line args has real effect.

So this PR removes the bogus defaults for the silence trim threshold that appear in the code, leaving just the one specified in command-line args.

Edit: I've also added a commit to allow us to skip silence trimming completely.

