### PR TITLE
[WIP] Compute loss for outputs only where receptive field is filled

### DIFF
--- a/test/test_loss.py
+++ b/test/test_loss.py
@@ -3,31 +3,31 @@ from __future__ import print_function
 import json
 import numpy as np
 import tensorflow as tf
-from wavenet import MakeLoss
+from wavenet import MakeLoss, ComputeReceptiveFieldSize
 
 
 def MakeLogits():
-    # 3 channels (quantization levels)
-    # 5 time steps in duration
     # 1 batch item
-    array = np.array([ [ [  5.0, -10.0, -10.0],
-                         [ 10.0, -10.0, -10.0],
-                         [  0.0,  10.0,   0.0],
-                         [-10.0,  10.0, -10.0],
-                         [-10.0,  10.0, -20.0] ] ])
+    # 5 time steps in duration
+    # 3 channels (quantization levels)
+    array = np.array([[[5.0,   -10.0, -10.0],
+                       [10.0,  -10.0, -10.0],
+                       [0.0,    10.0,   0.0],
+                       [-10.0,  10.0, -10.0],
+                       [-10.0,  10.0, -20.0]]])
 
     return tf.convert_to_tensor(array, tf.float32)
 
 
 def MakeLabels():
-    # 3 channels (quantization levels)
-    # 5 time steps in duration
     # 1 batch item
-    array = np.array([ [ [ 0.0, 1.0, 0.0],
-                         [ 0.0, 0.0, 1.0],
-                         [ 0.0, 0.0, 1.0],
-                         [ 0.0, 0.0, 1.0],
-                         [ 0.0, 0.0, 1.0] ] ])
+    # 5 time steps in duration
+    # 3 channels (quantization levels)
+    array = np.array([[[0.0, 1.0, 0.0],
+                       [0.0, 0.0, 1.0],
+                       [0.0, 0.0, 1.0],
+                       [0.0, 0.0, 1.0],
+                       [0.0, 0.0, 1.0]]])
     return tf.convert_to_tensor(array, tf.float32)
 
 
@@ -35,38 +35,48 @@ class TestLoss(tf.test.TestCase):
     def setUp(self):
         pass
 
-
     def testZeroReceptiveFieldSize(self):
         logits = MakeLogits()
         labels = MakeLabels()
 
-        loss = MakeLoss(labels, logits, quantization_channels = 3,
-                                     receptive_field_size = 0)
+        loss = MakeLoss(labels, logits, quantization_channels=3,
+                        receptive_field_size=0)
         with self.test_session() as sess:
             loss_array = sess.run([loss])
-        expected =np.array([[ 15.00000095, 20.0, 10.0, 20.0, 30.0]])
+        expected = np.array([[15.0, 20.0, 10.0, 20.0, 30.0]])
         EPSILON = 0.001
         np.testing.assert_allclose(expected, loss_array, rtol=EPSILON)
-
 
     def testNonZeroReceptiveFieldSize(self):
         logits = MakeLogits()
         labels = MakeLabels()
 
-        loss = MakeLoss(labels, logits, quantization_channels = 3,
-                                     receptive_field_size = 2)
+        loss = MakeLoss(labels, logits, quantization_channels=3,
+                        receptive_field_size=2)
         with self.test_session() as sess:
             loss_array = sess.run([loss])
 
         # Since we truncate the first receptive_field time elements from the
         # the tensors used to compute the loss, the losses should exclude the
-        # first two (since receptive_field_size is set to 2).
-        expected =np.array([[ 10.0, 20.0, 30.0]])
+        # first two (since receptive_field_size is set to 2) that we would
+        # otherwise have.
+        expected = np.array([[10.0, 20.0, 30.0]])
 
         EPSILON = 0.001
         np.testing.assert_allclose(expected, loss_array, rtol=EPSILON)
 
+    def testComputeReceptiveFieldSize_4(self):
+        dilations = [1, 2, 4]
+        computed_size = ComputeReceptiveFieldSize(dilations)
+        self.assertEqual(computed_size, 8)
+
+    def testComputeReceptiveFieldSize_256_256_256(self):
+        dilations = [1, 2, 4, 8, 16, 32, 64, 128, 256,
+                     1, 2, 4, 8, 16, 32, 64, 128, 256,
+                     1, 2, 4, 8, 16, 32, 64, 128, 256]
+        computed_size = ComputeReceptiveFieldSize(dilations)
+        self.assertEqual(computed_size, 512 + 511 + 511)
+
 
 if __name__ == '__main__':
     tf.test.main()
-

--- a/test/test_loss.py
+++ b/test/test_loss.py
@@ -1,0 +1,72 @@
+"""Unit tests for the loss function."""
+from __future__ import print_function
+import json
+import numpy as np
+import tensorflow as tf
+from wavenet import MakeLoss
+
+
+def MakeLogits():
+    # 3 channels (quantization levels)
+    # 5 time steps in duration
+    # 1 batch item
+    array = np.array([ [ [  5.0, -10.0, -10.0],
+                         [ 10.0, -10.0, -10.0],
+                         [  0.0,  10.0,   0.0],
+                         [-10.0,  10.0, -10.0],
+                         [-10.0,  10.0, -20.0] ] ])
+
+    return tf.convert_to_tensor(array, tf.float32)
+
+
+def MakeLabels():
+    # 3 channels (quantization levels)
+    # 5 time steps in duration
+    # 1 batch item
+    array = np.array([ [ [ 0.0, 1.0, 0.0],
+                         [ 0.0, 0.0, 1.0],
+                         [ 0.0, 0.0, 1.0],
+                         [ 0.0, 0.0, 1.0],
+                         [ 0.0, 0.0, 1.0] ] ])
+    return tf.convert_to_tensor(array, tf.float32)
+
+
+class TestLoss(tf.test.TestCase):
+    def setUp(self):
+        pass
+
+
+    def testZeroReceptiveFieldSize(self):
+        logits = MakeLogits()
+        labels = MakeLabels()
+
+        loss = MakeLoss(labels, logits, quantization_channels = 3,
+                                     receptive_field_size = 0)
+        with self.test_session() as sess:
+            loss_array = sess.run([loss])
+        expected =np.array([[ 15.00000095, 20.0, 10.0, 20.0, 30.0]])
+        EPSILON = 0.001
+        np.testing.assert_allclose(expected, loss_array, rtol=EPSILON)
+
+
+    def testNonZeroReceptiveFieldSize(self):
+        logits = MakeLogits()
+        labels = MakeLabels()
+
+        loss = MakeLoss(labels, logits, quantization_channels = 3,
+                                     receptive_field_size = 2)
+        with self.test_session() as sess:
+            loss_array = sess.run([loss])
+
+        # Since we truncate the first receptive_field time elements from the
+        # the tensors used to compute the loss, the losses should exclude the
+        # first two (since receptive_field_size is set to 2).
+        expected =np.array([[ 10.0, 20.0, 30.0]])
+
+        EPSILON = 0.001
+        np.testing.assert_allclose(expected, loss_array, rtol=EPSILON)
+
+
+if __name__ == '__main__':
+    tf.test.main()
+

--- a/test/test_loss.py
+++ b/test/test_loss.py
@@ -1,45 +1,38 @@
-"""Unit tests for the loss function."""
+"""Unit tests for the make_loss function."""
+
 from __future__ import print_function
 import json
 import numpy as np
+
 import tensorflow as tf
-from wavenet import make_loss, compute_receptive_field_size
+
+from wavenet import make_loss, compute_receptive_field
 
 
-def make_logits():
-    # 1 batch item
-    # 5 time steps in duration
-    # 3 channels (quantization levels)
-    array = np.array([[[5.0,   -10.0, -10.0],
-                       [10.0,  -10.0, -10.0],
-                       [0.0,    10.0,   0.0],
-                       [-10.0,  10.0, -10.0],
-                       [-10.0,  10.0, -20.0]]])
-
-    return tf.convert_to_tensor(array, tf.float32)
-
-
-def make_labels():
-    # 1 batch item
-    # 5 time steps in duration
-    # 3 channels (quantization levels)
-    array = np.array([[[0.0, 1.0, 0.0],
-                       [0.0, 0.0, 1.0],
-                       [0.0, 0.0, 1.0],
-                       [0.0, 0.0, 1.0],
-                       [0.0, 0.0, 1.0]]])
-    return tf.convert_to_tensor(array, tf.float32)
-
-
-class TestLoss(tf.test.TestCase):
+class TestMakeLoss(tf.test.TestCase):
     def setUp(self):
-        pass
+        # 1 batch item
+        # 5 time steps in duration
+        # 3 channels (quantization levels)
+        array = np.array([[[5.0,   -10.0, -10.0],
+                           [10.0,  -10.0, -10.0],
+                           [0.0,    10.0,   0.0],
+                           [-10.0,  10.0, -10.0],
+                           [-10.0,  10.0, -20.0]]])
+        self.logits = tf.convert_to_tensor(array, tf.float32)
+
+        # 1 batch item
+        # 5 time steps in duration
+        # 3 channels (quantization levels)
+        array = np.array([[[0.0, 1.0, 0.0],
+                           [0.0, 0.0, 1.0],
+                           [0.0, 0.0, 1.0],
+                           [0.0, 0.0, 1.0],
+                           [0.0, 0.0, 1.0]]])
+        self.labels = tf.convert_to_tensor(array, tf.float32)
 
     def test_zero_receptive_field_size(self):
-        logits = make_logits()
-        labels = make_labels()
-
-        loss = make_loss(labels, logits, quantization_channels=3,
+        loss = make_loss(self.labels, self.logits, quantization_channels=3,
                          receptive_field_size=0)
         with self.test_session() as sess:
             loss_array = sess.run([loss])
@@ -48,10 +41,7 @@ class TestLoss(tf.test.TestCase):
         np.testing.assert_allclose(expected, loss_array, rtol=EPSILON)
 
     def test_non_zero_receptive_field_size(self):
-        logits = make_logits()
-        labels = make_labels()
-
-        loss = make_loss(labels, logits, quantization_channels=3,
+        loss = make_loss(self.labels, self.logits, quantization_channels=3,
                          receptive_field_size=2)
         with self.test_session() as sess:
             loss_array = sess.run([loss])
@@ -65,16 +55,18 @@ class TestLoss(tf.test.TestCase):
         EPSILON = 0.001
         np.testing.assert_allclose(expected, loss_array, rtol=EPSILON)
 
-    def test_compute_receptive_field_size_4(self):
+
+class TestReceptiveFieldSize(tf.test.TestCase):
+    def test_single_stack(self):
         dilations = [1, 2, 4]
-        computed_size = compute_receptive_field_size(dilations)
+        computed_size = compute_receptive_field(dilations)
         self.assertEqual(computed_size, 8)
 
-    def test_compute_receptive_field_size_256_256_256(self):
+    def test_multiple_stacks(self):
         dilations = [1, 2, 4, 8, 16, 32, 64, 128, 256,
                      1, 2, 4, 8, 16, 32, 64, 128, 256,
                      1, 2, 4, 8, 16, 32, 64, 128, 256]
-        computed_size = compute_receptive_field_size(dilations)
+        computed_size = compute_receptive_field(dilations)
         self.assertEqual(computed_size, 512 + 511 + 511)
 
 

--- a/test/test_loss.py
+++ b/test/test_loss.py
@@ -3,10 +3,10 @@ from __future__ import print_function
 import json
 import numpy as np
 import tensorflow as tf
-from wavenet import MakeLoss, ComputeReceptiveFieldSize
+from wavenet import make_loss, compute_receptive_field_size
 
 
-def MakeLogits():
+def make_logits():
     # 1 batch item
     # 5 time steps in duration
     # 3 channels (quantization levels)
@@ -19,7 +19,7 @@ def MakeLogits():
     return tf.convert_to_tensor(array, tf.float32)
 
 
-def MakeLabels():
+def make_labels():
     # 1 batch item
     # 5 time steps in duration
     # 3 channels (quantization levels)
@@ -35,24 +35,24 @@ class TestLoss(tf.test.TestCase):
     def setUp(self):
         pass
 
-    def testZeroReceptiveFieldSize(self):
-        logits = MakeLogits()
-        labels = MakeLabels()
+    def test_zero_receptive_field_size(self):
+        logits = make_logits()
+        labels = make_labels()
 
-        loss = MakeLoss(labels, logits, quantization_channels=3,
-                        receptive_field_size=0)
+        loss = make_loss(labels, logits, quantization_channels=3,
+                         receptive_field_size=0)
         with self.test_session() as sess:
             loss_array = sess.run([loss])
         expected = np.array([[15.0, 20.0, 10.0, 20.0, 30.0]])
         EPSILON = 0.001
         np.testing.assert_allclose(expected, loss_array, rtol=EPSILON)
 
-    def testNonZeroReceptiveFieldSize(self):
-        logits = MakeLogits()
-        labels = MakeLabels()
+    def test_non_zero_receptive_field_size(self):
+        logits = make_logits()
+        labels = make_labels()
 
-        loss = MakeLoss(labels, logits, quantization_channels=3,
-                        receptive_field_size=2)
+        loss = make_loss(labels, logits, quantization_channels=3,
+                         receptive_field_size=2)
         with self.test_session() as sess:
             loss_array = sess.run([loss])
 
@@ -65,16 +65,16 @@ class TestLoss(tf.test.TestCase):
         EPSILON = 0.001
         np.testing.assert_allclose(expected, loss_array, rtol=EPSILON)
 
-    def testComputeReceptiveFieldSize_4(self):
+    def test_compute_receptive_field_size_4(self):
         dilations = [1, 2, 4]
-        computed_size = ComputeReceptiveFieldSize(dilations)
+        computed_size = compute_receptive_field_size(dilations)
         self.assertEqual(computed_size, 8)
 
-    def testComputeReceptiveFieldSize_256_256_256(self):
+    def test_compute_receptive_field_size_256_256_256(self):
         dilations = [1, 2, 4, 8, 16, 32, 64, 128, 256,
                      1, 2, 4, 8, 16, 32, 64, 128, 256,
                      1, 2, 4, 8, 16, 32, 64, 128, 256]
-        computed_size = ComputeReceptiveFieldSize(dilations)
+        computed_size = compute_receptive_field_size(dilations)
         self.assertEqual(computed_size, 512 + 511 + 511)
 
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -69,8 +69,8 @@ class TestNet(tf.test.TestCase):
             initial_loss = sess.run(loss)
             for i in range(TRAIN_ITERATIONS):
                 loss_val, _ = sess.run([loss, optim])
-                if i % 10 == 0:
-                    print("i: %d loss: %f" % (i, loss_val))
+                # if i % 10 == 0:
+                #     print("i: %d loss: %f" % (i, loss_val))
 
         # Sanity check the initial loss was larger.
         self.assertGreater(initial_loss, max_allowed_loss)

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -9,8 +9,8 @@ from wavenet import WaveNetModel, time_to_batch, batch_to_time, causal_conv
 
 SAMPLE_RATE_HZ = 2000.0  # Hz
 TRAIN_ITERATIONS = 400
-LEARN_RATE = 0.02
-SAMPLE_DURATION = 0.2  # Seconds
+LEARN_RATE = 0.01
+CLIP_DURATION = 0.2  # Seconds
 MOMENTUM = 0.9
 
 
@@ -22,7 +22,7 @@ def MakeSineWaves():
     f2 = 196.00  # G
     f3 = 233.08  # B-flat
     sample_period = 1.0/SAMPLE_RATE_HZ
-    times = np.arange(0.0, SAMPLE_DURATION, sample_period)
+    times = np.arange(0.0, CLIP_DURATION, sample_period)
 
     amplitudes = (np.sin(times * 2.0 * np.pi * f1) / 3.0 +
                   np.cos(times * 2.0 * np.pi * f2) / 3.0 +
@@ -34,8 +34,8 @@ def MakeSineWaves():
 class TestNet(tf.test.TestCase):
     def setUp(self):
         self.net = WaveNetModel(batch_size=1,
-                                dilations=[1, 2, 4, 8, 16, 32, 64, 128, 256,
-                                           1, 2, 4, 8, 16, 32, 64, 128, 256],
+                                dilations=[1, 2, 4, 8, 16, 32, 64,
+                                           1, 2, 4, 8, 16, 32, 64],
                                 filter_width=2,
                                 residual_channels=32,
                                 dilation_channels=32,
@@ -69,8 +69,8 @@ class TestNet(tf.test.TestCase):
             initial_loss = sess.run(loss)
             for i in range(TRAIN_ITERATIONS):
                 loss_val, _ = sess.run([loss, optim])
-                # if i % 10 == 0:
-                #     print("i: %d loss: %f" % (i, loss_val))
+                if i % 10 == 0:
+                    print("i: %d loss: %f" % (i, loss_val))
 
         # Sanity check the initial loss was larger.
         self.assertGreater(initial_loss, max_allowed_loss)
@@ -87,8 +87,8 @@ class TestNetWithBiases(TestNet):
 
     def setUp(self):
         self.net = WaveNetModel(batch_size=1,
-                                dilations=[1, 2, 4, 8, 16, 32, 64, 128, 256,
-                                           1, 2, 4, 8, 16, 32, 64, 128, 256],
+                                dilations=[1, 2, 4, 8, 16, 32, 64,
+                                           1, 2, 4, 8, 16, 32, 64],
                                 filter_width=2,
                                 residual_channels=32,
                                 dilation_channels=32,
@@ -101,8 +101,8 @@ class TestNetWithScalarInput(TestNet):
 
     def setUp(self):
         self.net = WaveNetModel(batch_size=1,
-                                dilations=[1, 2, 4, 8, 16, 32, 64, 128, 256,
-                                           1, 2, 4, 8, 16, 32, 64, 128, 256],
+                                dilations=[1, 2, 4, 8, 16, 32, 64,
+                                           1, 2, 4, 8, 16, 32, 64],
                                 filter_width=2,
                                 residual_channels=32,
                                 dilation_channels=32,

--- a/wavenet/__init__.py
+++ b/wavenet/__init__.py
@@ -1,4 +1,4 @@
-from .model import (WaveNetModel, MakeLoss, ComputeReceptiveFieldSize)
+from .model import (WaveNetModel, make_loss, compute_receptive_field_size)
 from .audio_reader import AudioReader
 from .ops import (mu_law_encode, mu_law_decode, time_to_batch,
                   batch_to_time, causal_conv)

--- a/wavenet/__init__.py
+++ b/wavenet/__init__.py
@@ -1,4 +1,4 @@
-from .model import (WaveNetModel, MakeLoss)
+from .model import (WaveNetModel, MakeLoss, ComputeReceptiveFieldSize)
 from .audio_reader import AudioReader
 from .ops import (mu_law_encode, mu_law_decode, time_to_batch,
                   batch_to_time, causal_conv)

--- a/wavenet/__init__.py
+++ b/wavenet/__init__.py
@@ -1,4 +1,4 @@
-from .model import (WaveNetModel, make_loss, compute_receptive_field_size)
+from .model import WaveNetModel, make_loss, compute_receptive_field
 from .audio_reader import AudioReader
 from .ops import (mu_law_encode, mu_law_decode, time_to_batch,
                   batch_to_time, causal_conv)

--- a/wavenet/__init__.py
+++ b/wavenet/__init__.py
@@ -1,4 +1,4 @@
-from .model import WaveNetModel
+from .model import (WaveNetModel, MakeLoss)
 from .audio_reader import AudioReader
 from .ops import (mu_law_encode, mu_law_decode, time_to_batch,
                   batch_to_time, causal_conv)

--- a/wavenet/audio_reader.py
+++ b/wavenet/audio_reader.py
@@ -101,11 +101,11 @@ class AudioReader(object):
                               "trimming, it was shorter than the receptive "
                               "field of the net. ".format(filename))
 
-                # If the trimmed audio is less than the receptive field size,
-                # then tf.slice performed by loss will fail. So skip the file
-                # if this is the case.
+                # If the trimmed audio is shorter than the receptive field
+                # size, then tf.slice performed by loss will fail. Skip the
+                # file if this is the case.
                 if audio.size > self.receptive_field_size:
-                    if self.sample_size:
+                    if self.sample_size > 0:
                         # Cut samples into fixed size pieces
                         buffer_ = np.append(buffer_, audio)
                         while len(buffer_) > self.sample_size:

--- a/wavenet/audio_reader.py
+++ b/wavenet/audio_reader.py
@@ -57,6 +57,7 @@ class AudioReader(object):
                  audio_dir,
                  coord,
                  sample_rate,
+                 receptive_field_size,
                  sample_size=None,
                  silence_threshold=None,
                  queue_size=256):
@@ -71,6 +72,7 @@ class AudioReader(object):
                                          ['float32'],
                                          shapes=[(None, 1)])
         self.enqueue = self.queue.enqueue([self.sample_placeholder])
+        self.receptive_field_size = receptive_field_size
 
     def dequeue(self, num_elements):
         output = self.queue.dequeue_many(num_elements)
@@ -94,18 +96,28 @@ class AudioReader(object):
                               "silence. Consider decreasing trim_silence "
                               "threshold, or adjust volume of the audio."
                               .format(filename))
+                    if audio.size <= self.receptive_field_size:
+                        print("Warning: {} was ignored since, after silence "
+                              "trimming, it was shorter than the receptive "
+                              "field of the net. ".format(filename))
 
-                if self.sample_size:
-                    # Cut samples into fixed size pieces
-                    buffer_ = np.append(buffer_, audio)
-                    while len(buffer_) > self.sample_size:
-                        piece = np.reshape(buffer_[:self.sample_size], [-1, 1])
+                # If the trimmed audio is less than the receptive field size,
+                # then tf.slice performed by loss will fail. So skip the file
+                # if this is the case.
+                if audio.size > self.receptive_field_size:
+                    if self.sample_size:
+                        # Cut samples into fixed size pieces
+                        buffer_ = np.append(buffer_, audio)
+                        while len(buffer_) > self.sample_size:
+                            piece = np.reshape(buffer_[:self.sample_size],
+                                               [-1, 1])
+                            sess.run(self.enqueue,
+                                     feed_dict=
+                                     {self.sample_placeholder: piece})
+                            buffer_ = buffer_[self.sample_size:]
+                    else:
                         sess.run(self.enqueue,
-                                 feed_dict={self.sample_placeholder: piece})
-                        buffer_ = buffer_[self.sample_size:]
-                else:
-                    sess.run(self.enqueue,
-                             feed_dict={self.sample_placeholder: audio})
+                                 feed_dict={self.sample_placeholder: audio})
 
     def start_threads(self, sess, n_threads=1):
         for _ in range(n_threads):

--- a/wavenet/audio_reader.py
+++ b/wavenet/audio_reader.py
@@ -112,8 +112,8 @@ class AudioReader(object):
                             piece = np.reshape(buffer_[:self.sample_size],
                                                [-1, 1])
                             sess.run(self.enqueue,
-                                     feed_dict=
-                                     {self.sample_placeholder: piece})
+                                     feed_dict={self.sample_placeholder:
+                                                piece})
                             buffer_ = buffer_[self.sample_size:]
                     else:
                         sess.run(self.enqueue,

--- a/wavenet/model.py
+++ b/wavenet/model.py
@@ -18,9 +18,10 @@ def create_bias_variable(name, shape):
     return tf.Variable(initializer(shape=shape), name)
 
 
-def MakeLoss(labels, logits, quantization_channels, receptive_field_size):
+def make_loss(labels, logits, quantization_channels, receptive_field_size):
     '''Create the loss function from the net's raw output (softmax logits)
     and the labels (as probs).
+
     Arguments:
         labels: Target probability tensor, shape: [batch size,
                 duration in time steps, channels (quantization levels)]
@@ -29,15 +30,14 @@ def MakeLoss(labels, logits, quantization_channels, receptive_field_size):
                 softmax to create the discrete probability distribution.
                 shape: same as labels.
 
-        quantization_channels: Number of possible one-hot values for which the
-                               softmax gives us a discrete probability
-                               distribution.
+        quantization_channels:
+                Number of possible one-hot values for which the softmax gives
+                us a discrete probability distribution.
 
-        receptive_field_size: The integer size of the receptive field of the
-                              wavenet, as determined by the dilations and
-                              filter_size config params.
+        receptive_field_size:
+                The integer size of the receptive field of the wavenet, as
+                determined by the dilations and filter_size config params.
     '''
-
     if receptive_field_size > 0:
         # Skip the portion of the time history where the receptive
         # field of the output is not yet entirely filled.
@@ -51,9 +51,13 @@ def MakeLoss(labels, logits, quantization_channels, receptive_field_size):
     return loss
 
 
-def ComputeReceptiveFieldSize(dilations):
+def compute_receptive_field_size(dilations):
     '''Given the list of dilations, return the receptive field size of the
     net.
+
+    Arguments:
+        dilations: List of dilation values used by the dilated convolutions.
+
     WARNING: this implemenation is only exactly correct for dilations list
     of the following form:
         [1, 2, 4, 8, ... 2**m,
@@ -556,9 +560,9 @@ class WaveNetModel(object):
                                    [-1, tf.shape(encoded)[1] - 1, -1])
                 shifted = tf.pad(shifted, [[0, 0], [0, 1], [0, 0]])
 
-                loss = MakeLoss(shifted, raw_output,
-                                self.quantization_channels,
-                                ComputeReceptiveFieldSize(self.dilations))
+                loss = make_loss(shifted, raw_output,
+                                 self.quantization_channels,
+                                 compute_receptive_field_size(self.dilations))
                 reduced_loss = tf.reduce_mean(loss)
 
                 tf.scalar_summary('loss', reduced_loss)


### PR DESCRIPTION
This is my attempt at a fix for [issue 98](https://github.com/ibab/tensorflow-wavenet/issues/98), using nakosung's suggested solution.

I've merged it into a branch I'm training on, and there is not an immediate drop to lower reported loss. Though it might be learning a bit faster. Hard to say. At least it doesn't appear to have broken anything.
