### PR TITLE
Save and load only trainable vars

### DIFF
--- a/train.py
+++ b/train.py
@@ -227,7 +227,7 @@ def main():
     sess.run(init)
 
     # Saver for storing checkpoints of the model.
-    saver = tf.train.Saver()
+    saver = tf.train.Saver(var_list=tf.trainable_variables())
 
     try:
         saved_global_step = load(saver, sess, restore_from)


### PR DESCRIPTION
Currently we save, and try to load, all variables including ones particular to the optimizer. This prevents one from changing the optimizer, and resuming training from a saved checkpoint.

I found that if we only save the trainable vars then I can change the optimizer and resume training from a saved checkpoint.

Is there some reason why saving all the variables is preferable?
