### PR TITLE
Replace sum() with tf.add_n()

### DIFF
--- a/wavenet/model.py
+++ b/wavenet/model.py
@@ -325,7 +325,7 @@ class WaveNetModel(object):
 
             # We skip connections from the outputs of each layer, adding them
             # all up here.
-            total = sum(outputs)
+            total = tf.add_n(outputs)
             transformed1 = tf.nn.relu(total)
             conv1 = tf.nn.conv1d(transformed1, w1, stride=1, padding="SAME")
             if self.use_biases:
@@ -398,7 +398,7 @@ class WaveNetModel(object):
 
             # We skip connections from the outputs of each layer, adding them
             # all up here.
-            total = sum(outputs)
+            total = tf.add_n(outputs)
             transformed1 = tf.nn.relu(total)
 
             conv1 = tf.matmul(transformed1, w1[0, :, :])


### PR DESCRIPTION
I think this might be better because on the GPU it would end up storing the result of the summation to global memory once, instead of n-1 times. I also fear a bunch of cascaded summations ends up creating multiple intermediate tensors which each have to be allocated and use up memory.

In other words, sum(A) creates a graph that does:
sum1 = a1+a2
sum2 = sum1 + a3
sum3 = sum2 + a4
...

instead of tf.add_n() which just does:
sum = a1 + a2 + a3 + a4 + ...

I don't really know for sure.
