### PR TITLE
Add generation test

### DIFF
--- a/test/test_model.py
+++ b/test/test_model.py
@@ -99,7 +99,7 @@ def check_waveform(assertion, generated_waveform):
     f3_power = find_nearest(freqs, power_spectrum, F3)
     expected_power = f1_power + f2_power + f3_power
     # print("Power sum {}, F1 power:{}, F2 power:{}, F3 power:{}".
-    #        format(power_sum, f1_power, f2_power, f3_power))
+    #       format(power_sum, f1_power, f2_power, f3_power))
 
     # Expect most of the power to be at the 3 frequencies we trained
     # on.

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -99,7 +99,7 @@ def check_waveform(assertion, generated_waveform):
     f3_power = find_nearest(freqs, power_spectrum, F3)
     expected_power = f1_power + f2_power + f3_power
     # print("Power sum {}, F1 power:{}, F2 power:{}, F3 power:{}".
-    #       format(power_sum, f1_power, f2_power, f3_power))
+    #        format(power_sum, f1_power, f2_power, f3_power))
 
     # Expect most of the power to be at the 3 frequencies we trained
     # on.
@@ -186,6 +186,7 @@ class TestNet(tf.test.TestCase):
 
 
 class TestNetWithBiases(TestNet):
+
     def setUp(self):
         self.net = WaveNetModel(batch_size=1,
                                 dilations=[1, 2, 4, 8, 16, 32, 64,
@@ -233,8 +234,8 @@ class TestNetWithScalarInput(TestNet):
                                 skip_channels=32,
                                 scalar_input=True,
                                 initial_filter_width=4)
-        self.optimizer_type = 'sgd'
-        self.learning_rate = 0.02
+        self.optimizer_type = 'rmsprop'
+        self.learning_rate = 0.001
         self.generate = False
         self.momentum = MOMENTUM_SCALAR_INPUT
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -3,7 +3,10 @@
 import json
 
 import numpy as np
+import sys
 import tensorflow as tf
+# import matplotlib.pyplot as plt
+import librosa
 
 from wavenet import (WaveNetModel, time_to_batch, batch_to_time, causal_conv,
                      optimizer_factory)
@@ -11,24 +14,61 @@ from wavenet import (WaveNetModel, time_to_batch, batch_to_time, causal_conv,
 SAMPLE_RATE_HZ = 2000.0  # Hz
 TRAIN_ITERATIONS = 400
 SAMPLE_DURATION = 0.2  # Seconds
-MOMENTUM = 0.9
+SAMPLE_DURATION = 0.5  # Duration of the training sample. Seconds
+MOMENTUM = 0.95
+MOMENTUM_SCALAR_INPUT = 0.9
+GENERATE_SAMPLES = 1000
+QUANTIZATION_CHANNELS = 256
+F1 = 155.56  # E-flat frequency in hz
+F2 = 196.00  # G frequency in hz
+F3 = 233.08  # B-flat frequency in hz
 
 
-def MakeSineWaves():
+def make_sine_waves():
     """Creates a time-series of audio amplitudes corresponding to 3
     superimposed sine waves."""
-    # Frequencies of the sine waves in Hz.
-    f1 = 155.56  # E-flat
-    f2 = 196.00  # G
-    f3 = 233.08  # B-flat
     sample_period = 1.0/SAMPLE_RATE_HZ
     times = np.arange(0.0, SAMPLE_DURATION, sample_period)
 
-    amplitudes = (np.sin(times * 2.0 * np.pi * f1) / 3.0 +
-                  np.cos(times * 2.0 * np.pi * f2) / 3.0 +
-                  np.sin(times * 2.0 * np.pi * f3) / 3.0)
+    amplitudes = (np.sin(times * 2.0 * np.pi * F1) / 3.0 +
+                  np.sin(times * 2.0 * np.pi * F2) / 3.0 +
+                  np.sin(times * 2.0 * np.pi * F3) / 3.0)
 
     return amplitudes
+
+
+def generate_waveform(sess, net):
+    samples = tf.placeholder(tf.int32)
+    next_sample_probs = net.predict_proba(samples)
+    waveform = [128]
+    decode = mu_law_decode(samples, QUANTIZATION_CHANNELS)
+    for i in range(GENERATE_SAMPLES):
+        if len(waveform) > 256:
+            window = waveform[-256:]
+        else:
+            window = waveform
+
+        # Run the WaveNet to predict the next sample.
+        prediction = sess.run([next_sample_probs],
+                              feed_dict={samples: window})[0]
+        sample = np.random.choice(
+           np.arange(QUANTIZATION_CHANNELS), p=prediction)
+        # sample = np.argmax(prediction)
+        waveform.append(sample)
+        # print("Generated {} of {}: {}".format(i,GENERATE_SAMPLES, sample))
+        # sys.stdout.flush()
+
+    # Skip the first number of samples equal to the size of the receptive
+    # field.
+    waveform = np.array(waveform[256:])
+    decoded_waveform = sess.run(decode, feed_dict={samples: waveform})
+    return decoded_waveform
+
+
+def find_nearest(freqs, power_spectrum, frequency):
+    # Return the power of the bin nearest to the target frequency.
+    index = (np.abs(freqs - frequency)).argmin()
+    return power_spectrum[index]
 
 
 class TestNet(tf.test.TestCase):
@@ -43,6 +83,8 @@ class TestNet(tf.test.TestCase):
                                 skip_channels=32)
         self.optimizer_type = 'adam'
         self.learning_rate = 0.002
+        self.generate = False
+        self.momentum = MOMENTUM
 
     # Train a net on a short clip of 3 sine waves superimposed
     # (an e-flat chord).
@@ -52,8 +94,19 @@ class TestNet(tf.test.TestCase):
     # training, and learns this waveform.
 
     def testEndToEndTraining(self):
-        audio = MakeSineWaves()
+        audio = make_sine_waves()
         np.random.seed(42)
+
+        # if self.generate:
+        #    librosa.output.write_wav('/tmp/sine_train.wav', audio,
+        #                             SAMPLE_RATE_HZ)
+        #    power_spectrum = np.abs(np.fft.fft(audio))**2
+        #    freqs = np.fft.fftfreq(audio.size, SAMPLE_PERIOD_SECS)
+        #    indices = np.argsort(freqs)
+        #    indices = [index for index in indices if freqs[index] >= 0 and
+        #                                             freqs[index] <= 500.0]
+        #    plt.plot(freqs[indices], power_spectrum[indices])
+        #    plt.show()
 
         audio_tensor = tf.convert_to_tensor(audio, dtype=tf.float32)
         loss = self.net.loss(audio_tensor)
@@ -63,6 +116,7 @@ class TestNet(tf.test.TestCase):
         optim = optimizer.minimize(loss, var_list=trainable)
         init = tf.initialize_all_variables()
 
+        generated_waveform = None
         max_allowed_loss = 0.1
         loss_val = max_allowed_loss
         initial_loss = None
@@ -71,22 +125,50 @@ class TestNet(tf.test.TestCase):
             initial_loss = sess.run(loss)
             for i in range(TRAIN_ITERATIONS):
                 loss_val, _ = sess.run([loss, optim])
-                # if i % 10 == 0 or i == TRAIN_ITERATIONS-1:
-                #     print("i: %d loss: %f" % (i, loss_val))
+                # if i % 10 == 0:
+                #    print("i: %d loss: %f" % (i, loss_val))
 
-        # Sanity check the initial loss was larger.
-        self.assertGreater(initial_loss, max_allowed_loss)
+            # Sanity check the initial loss was larger.
+            self.assertGreater(initial_loss, max_allowed_loss)
 
-        # Loss after training should be small.
-        self.assertLess(loss_val, max_allowed_loss)
+            # Loss after training should be small.
+            self.assertLess(loss_val, max_allowed_loss)
 
-        # Loss should be at least two orders of magnitude better
-        # than before training.
-        self.assertLess(loss_val / initial_loss, 0.01)
+            # Loss should be at least two orders of magnitude better
+            # than before training.
+            self.assertLess(loss_val / initial_loss, 0.01)
+
+            # saver = tf.train.Saver(var_list=tf.trainable_variables())
+            # saver.save(sess, '/tmp/sine_test_model.ckpt', global_step=i)
+            if self.generate:
+                generated_waveform = generate_waveform(sess, self.net)
+
+        if generated_waveform is not None:
+            # librosa.output.write_wav('/tmp/sine_test.wav',
+            #                          generated_waveform,
+            #                          SAMPLE_RATE_HZ)
+            power_spectrum = np.abs(np.fft.fft(generated_waveform))**2
+            freqs = np.fft.fftfreq(generated_waveform.size, SAMPLE_PERIOD_SECS)
+            indices = np.argsort(freqs)
+            indices = [index for index in indices if freqs[index] >= 0 and
+                       freqs[index] <= 500.0]
+            power_spectrum = power_spectrum[indices]
+            freqs = freqs[indices]
+            # plt.plot(freqs[indices], power_spectrum[indices])
+            # plt.show()
+            power_sum = np.sum(power_spectrum)
+            f1_power = find_nearest(freqs, power_spectrum, F1)
+            f2_power = find_nearest(freqs, power_spectrum, F2)
+            f3_power = find_nearest(freqs, power_spectrum, F3)
+            expected_power = f1_power + f2_power + f3_power
+            # print("Power sum {}, F1 power:{}, F2 power:{}, F3 power:{}".
+            #       format(power_sum, f1_power, f2_power, f3_power))
+            # Expect most of the power to be at the 3 frequencies we trained
+            # on.
+            self.assertGreater(expected_power, 0.9 * power_sum)
 
 
 class TestNetWithBiases(TestNet):
-
     def setUp(self):
         self.net = WaveNetModel(batch_size=1,
                                 dilations=[1, 2, 4, 8, 16, 32, 64,
@@ -111,9 +193,11 @@ class TestNetWithRMSProp(TestNet):
                                 residual_channels=32,
                                 dilation_channels=32,
                                 quantization_channels=256,
-                                skip_channels=32)
+                                skip_channels=256)
         self.optimizer_type = 'rmsprop'
         self.learning_rate = 0.001
+        self.generate = True
+        self.momentum = MOMENTUM
 
 
 class TestNetWithScalarInput(TestNet):
@@ -132,6 +216,8 @@ class TestNetWithScalarInput(TestNet):
                                 initial_filter_width=4)
         self.optimizer_type = 'sgd'
         self.learning_rate = 0.02
+        self.generate = False
+        self.momentum = MOMENTUM_SCALAR_INPUT
 
 
 if __name__ == '__main__':

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -6,7 +6,7 @@ import numpy as np
 import sys
 import tensorflow as tf
 # import matplotlib.pyplot as plt
-import librosa
+# import librosa
 
 from wavenet import (WaveNetModel, time_to_batch, batch_to_time, causal_conv,
                      optimizer_factory)

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -6,11 +6,7 @@ import numpy as np
 import sys
 import tensorflow as tf
 # import matplotlib.pyplot as plt
-<<<<<<< HEAD
 # import librosa
-=======
-import librosa
->>>>>>> Add generation test.
 
 from wavenet import (WaveNetModel, time_to_batch, batch_to_time, causal_conv,
                      optimizer_factory, mu_law_decode)

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -6,7 +6,11 @@ import numpy as np
 import sys
 import tensorflow as tf
 # import matplotlib.pyplot as plt
+<<<<<<< HEAD
 # import librosa
+=======
+import librosa
+>>>>>>> Add generation test.
 
 from wavenet import (WaveNetModel, time_to_batch, batch_to_time, causal_conv,
                      optimizer_factory, mu_law_decode)
@@ -116,8 +120,8 @@ class TestNet(tf.test.TestCase):
                                 dilation_channels=32,
                                 quantization_channels=256,
                                 skip_channels=32)
-        self.optimizer_type = 'adam'
-        self.learning_rate = 0.002
+        self.optimizer_type = 'sgd'
+        self.learning_rate = 0.02
         self.generate = False
         self.momentum = MOMENTUM
 
@@ -186,7 +190,6 @@ class TestNet(tf.test.TestCase):
 
 
 class TestNetWithBiases(TestNet):
-
     def setUp(self):
         self.net = WaveNetModel(batch_size=1,
                                 dilations=[1, 2, 4, 8, 16, 32, 64,
@@ -234,8 +237,8 @@ class TestNetWithScalarInput(TestNet):
                                 skip_channels=32,
                                 scalar_input=True,
                                 initial_filter_width=4)
-        self.optimizer_type = 'rmsprop'
-        self.learning_rate = 0.001
+        self.optimizer_type = 'sgd'
+        self.learning_rate = 0.02
         self.generate = False
         self.momentum = MOMENTUM_SCALAR_INPUT
 


### PR DESCRIPTION
I hacked in a test to check generation. Right now it just tests WaveNetModel.predict_proba(), not yet WaveNetModel.predict_prob_incremental(). I duplicated a bit of code from generate.py to do it; it's a bit ugly.

The only idea I came up with was to check that the power spectrum of the generated waveform matches what we trained it on. So the training signal looks like this:

![sine_train](https://cloud.githubusercontent.com/assets/2138320/19260829/6ffc7d38-8f52-11e6-8e5b-5b3d74e54930.png)

with peaks at the three frequencies we expect.

A successfully generated waveform looks like this:
![sine_generated](https://cloud.githubusercontent.com/assets/2138320/19260729/aae81836-8f51-11e6-8b28-395bc5a52264.png)

So the test just adds up the power in generated waveform's spectrum, and asserts that at least 90% of it is at those three frequencies. 

I had to train longer to get good results, and generation takes a while. I'm afraid our CI test is getting prohibitively-long. Takes a couple minutes even on the GPU. Afraid to see how long it takes on the CI server.

Is this reasonable approach? Suggestions?

And just for fun, [this](https://soundcloud.com/user-731806733/tf-wavenet-unit-test-sinewave) is what our training signal sounds like.