### PR TITLE
Exit without error when num_steps exceeded

### DIFF
--- a/train.py
+++ b/train.py
@@ -257,6 +257,7 @@ def main():
     threads = tf.train.start_queue_runners(sess=sess, coord=coord)
     reader.start_threads(sess)
 
+    step = None
     try:
         last_saved_step = saved_global_step
         for step in range(saved_global_step + 1, args.num_steps):


### PR DESCRIPTION
There is a defect where, when you resume training from a checkpoint and the saved num steps already exceeds the --num_steps, it exits with a python exception saying that step is referenced before assignment. This is a trivial fix for that.