### PR TITLE
The u-law encoding is badly mapping values from the [-1,1] range to [0,255]

### DIFF
--- a/wavenet/ops.py
+++ b/wavenet/ops.py
@@ -70,7 +70,7 @@ def mu_law_encode(audio, quantization_channels):
         magnitude = tf.log(1 + mu * tf.abs(audio)) / tf.log(1. + mu)
         signal = tf.sign(audio) * magnitude
         # Quantize signal to the specified number of levels.
-        return tf.cast((signal + 1) / 2 * mu + 0.5, tf.int32)
+        return tf.cast(((signal + 1) * mu) / 2, tf.int32)
 
 
 def mu_law_decode(output, quantization_channels):


### PR DESCRIPTION
The u-law encoding was badly mapping values from the [-1,1] range to [0,255].

The correct equation to do this is (tested): 
return tf.cast(((signal + 1) * mu) / 2, tf.int32)