### PR TITLE
fix a bug of wrong dimension when sample_size=0

### DIFF
--- a/wavenet/audio_reader.py
+++ b/wavenet/audio_reader.py
@@ -95,6 +95,7 @@ class AudioReader(object):
                 if self.silence_threshold is not None:
                     # Remove silence
                     audio = trim_silence(audio[:, 0], self.silence_threshold)
+                    audio = audio.reshape(-1, 1)
                     if audio.size == 0:
                         print("Warning: {} was ignored as it contains only "
                               "silence. Consider decreasing trim_silence "


### PR DESCRIPTION
When we want to feed all the audio file into the queue with sample_size=0, after `trim_silence()`, the `audio` variable is a row vector, which should be reshaped before `sess.run(self.enqueue, feed_dict={self.sample_placeholder: audio})`.