### PR TITLE
Adding local and global features to AudioReader queue

### DIFF
--- a/train.py
+++ b/train.py
@@ -214,7 +214,7 @@ def main():
             sample_rate=wavenet_params['sample_rate'],
             sample_size=args.sample_size,
             silence_threshold=args.silence_threshold)
-        audio_batch = reader.dequeue(args.batch_size)
+        audio_batch, gf_batch, lf_batch = reader.dequeue(args.batch_size)
 
     # Create network.
     net = WaveNetModel(

--- a/wavenet/audio_reader.py
+++ b/wavenet/audio_reader.py
@@ -39,15 +39,16 @@ def load_vctk_audio(directory, sample_rate):
         yield audio, speaker_id, None
 
 
-def trim_silence(audio, threshold, local_features = None):
+def trim_silence(audio, threshold, local_features=None):
     '''Removes silence at the beginning and end of a sample.'''
     energy = librosa.feature.rmse(audio)
     frames = np.nonzero(energy > threshold)
     indices = librosa.core.frames_to_samples(frames)[1]
     audio_piece = audio[indices[0]:indices[-1]] if indices.size else audio[0:0]
-    local_features_piece = local_features[indices[0]:indices[-1] \
-        if indices.size else local_features[0:0]]
-        
+    local_features_piece = local_features[indices[0]:
+                                          indices[-1] if indices.size
+                                          else local_features[0:0]]
+
     # Note: indices can be an empty array, if the whole audio was silence.
     return audio_piece, local_features_piece
 
@@ -110,11 +111,11 @@ class AudioReader(object):
                 if self.silence_threshold is not None:
                     # Remove silence
                     audio, local_features = \
-                        trim_silence(audio[:, 0], 
-                                     self.silence_threshold, 
+                        trim_silence(audio[:, 0],
+                                     self.silence_threshold,
                                      local_features)
                     audio = audio.reshape(-1, 1)
-                    local_features = local_features.reshape(-1,1)
+                    local_features = local_features.reshape(-1, 1)
                     if audio.size == 0:
                         print("Warning: {} was ignored as it contains only "
                               "silence. Consider decreasing trim_silence "
@@ -124,26 +125,26 @@ class AudioReader(object):
                 if self.sample_size:
                     # Cut samples into fixed size pieces
                     for start_index in range(0, len(audio), self.sample_size):
-                        audio_piece = audio[start_index: start_index \
-                            + self.sample_size]
-                        lf_piece = local_features[start_index: start_index \
-                            + self.sample_size]
+                        audio_piece = audio[start_index: start_index +
+                                            self.sample_size]
+                        lf_piece = local_features[start_index: start_index +
+                                                  self.sample_size]
                         sess.run(
                             self.enqueue,
                             feed_dict={
-                                self.sample_placeholder: audio_piece,
-                                self.global_feature_placeholder: global_feature,
-                                self.local_features_placeholder: lf_piece,
-                                }
+                               self.sample_placeholder: audio_piece,
+                               self.global_feature_placeholder: global_feature,
+                               self.local_features_placeholder: lf_piece,
+                            }
                             )
                 else:
                     sess.run(
                             self.enqueue,
                             feed_dict={
-                                self.sample_placeholder: audio,
-                                self.global_feature_placeholder: global_feature,
-                                self.local_features_placeholder: local_features,
-                                }
+                               self.sample_placeholder: audio,
+                               self.global_feature_placeholder: global_feature,
+                               self.local_features_placeholder: local_features,
+                               }
                             )
 
     def start_threads(self, sess, n_threads=1):

--- a/wavenet/audio_reader.py
+++ b/wavenet/audio_reader.py
@@ -23,7 +23,7 @@ def load_generic_audio(directory, sample_rate):
     for filename in files:
         audio, _ = librosa.load(filename, sr=sample_rate, mono=True)
         audio = audio.reshape(-1, 1)
-        yield audio, filename
+        yield audio, None, None
 
 
 def load_vctk_audio(directory, sample_rate):
@@ -36,17 +36,20 @@ def load_vctk_audio(directory, sample_rate):
         audio = audio.reshape(-1, 1)
         matches = speaker_re.findall(filename)[0]
         speaker_id, recording_id = [int(id_) for id_ in matches]
-        yield audio, speaker_id
+        yield audio, speaker_id, None
 
 
-def trim_silence(audio, threshold):
+def trim_silence(audio, threshold, local_features = None):
     '''Removes silence at the beginning and end of a sample.'''
     energy = librosa.feature.rmse(audio)
     frames = np.nonzero(energy > threshold)
     indices = librosa.core.frames_to_samples(frames)[1]
-
+    audio_piece = audio[indices[0]:indices[-1]] if indices.size else audio[0:0]
+    local_features_piece = local_features[indices[0]:indices[-1] \
+        if indices.size else local_features[0:0]]
+        
     # Note: indices can be an empty array, if the whole audio was silence.
-    return audio[indices[0]:indices[-1]] if indices.size else audio[0:0]
+    return audio_piece, local_features_piece
 
 
 class AudioReader(object):
@@ -66,11 +69,18 @@ class AudioReader(object):
         self.sample_size = sample_size
         self.silence_threshold = silence_threshold
         self.threads = []
-        self.sample_placeholder = tf.placeholder(dtype=tf.float32, shape=None)
+        self.sample_placeholder = \
+            tf.placeholder(dtype=tf.float32, shape=None, name='audio')
+        self.global_feature_placeholder = \
+            tf.placeholder(dtype=tf.float64, shape=None, name='global_feature')
+        self.local_features_placeholder = \
+            tf.placeholder(dtype=tf.float64, shape=None, name='local_features')
         self.queue = tf.PaddingFIFOQueue(queue_size,
-                                         ['float32'],
-                                         shapes=[(None, 1)])
-        self.enqueue = self.queue.enqueue([self.sample_placeholder])
+                                         ['float32', 'float64', 'float64'],
+                                         shapes=[(None, 1), (), (None, 1)])
+        self.enqueue = self.queue.enqueue([self.sample_placeholder,
+                                           self.global_feature_placeholder,
+                                           self.local_features_placeholder])
 
         # TODO Find a better way to check this.
         # Checking inside the AudioReader's thread makes it hard to terminate
@@ -87,15 +97,24 @@ class AudioReader(object):
         stop = False
         # Go through the dataset multiple times
         while not stop:
-            iterator = load_generic_audio(self.audio_dir, self.sample_rate)
-            for audio, filename in iterator:
+            # iterator = load_generic_audio(self.audio_dir, self.sample_rate)
+            iterator = load_vctk_audio(self.audio_dir, self.sample_rate)
+            for audio, global_feature, local_features in iterator:
                 if self.coord.should_stop():
                     stop = True
                     break
+                if not global_feature:
+                    global_feature = 0.0
+                if not local_features:
+                    local_features = np.zeros_like(audio)
                 if self.silence_threshold is not None:
                     # Remove silence
-                    audio = trim_silence(audio[:, 0], self.silence_threshold)
+                    audio, local_features = \
+                        trim_silence(audio[:, 0], 
+                                     self.silence_threshold, 
+                                     local_features)
                     audio = audio.reshape(-1, 1)
+                    local_features = local_features.reshape(-1,1)
                     if audio.size == 0:
                         print("Warning: {} was ignored as it contains only "
                               "silence. Consider decreasing trim_silence "
@@ -104,15 +123,28 @@ class AudioReader(object):
 
                 if self.sample_size:
                     # Cut samples into fixed size pieces
-                    buffer_ = np.append(buffer_, audio)
-                    while len(buffer_) > self.sample_size:
-                        piece = np.reshape(buffer_[:self.sample_size], [-1, 1])
-                        sess.run(self.enqueue,
-                                 feed_dict={self.sample_placeholder: piece})
-                        buffer_ = buffer_[self.sample_size:]
+                    for start_index in range(0, len(audio), self.sample_size):
+                        audio_piece = audio[start_index: start_index \
+                            + self.sample_size]
+                        lf_piece = local_features[start_index: start_index \
+                            + self.sample_size]
+                        sess.run(
+                            self.enqueue,
+                            feed_dict={
+                                self.sample_placeholder: audio_piece,
+                                self.global_feature_placeholder: global_feature,
+                                self.local_features_placeholder: lf_piece,
+                                }
+                            )
                 else:
-                    sess.run(self.enqueue,
-                             feed_dict={self.sample_placeholder: audio})
+                    sess.run(
+                            self.enqueue,
+                            feed_dict={
+                                self.sample_placeholder: audio,
+                                self.global_feature_placeholder: global_feature,
+                                self.local_features_placeholder: local_features,
+                                }
+                            )
 
     def start_threads(self, sess, n_threads=1):
         for _ in range(n_threads):

--- a/wavenet/audio_reader.py
+++ b/wavenet/audio_reader.py
@@ -98,8 +98,7 @@ class AudioReader(object):
         stop = False
         # Go through the dataset multiple times
         while not stop:
-            # iterator = load_generic_audio(self.audio_dir, self.sample_rate)
-            iterator = load_vctk_audio(self.audio_dir, self.sample_rate)
+            iterator = load_generic_audio(self.audio_dir, self.sample_rate)
             for audio, global_feature, local_features in iterator:
                 if self.coord.should_stop():
                     stop = True


### PR DESCRIPTION
In order to do local/global conditioning, we need the queue manager to enqueue/batch the audio together with the local and global features.

In this PR: AudioReader queue will enqueue (audio, global_features, local_features), if no global/local features are given, they default to zero with the appropriate shape.