### PR TITLE
Fix a bug preventing training without conditioning

### DIFF
--- a/wavenet/audio_reader.py
+++ b/wavenet/audio_reader.py
@@ -49,7 +49,7 @@ def load_generic_audio(directory, sample_rate):
     randomized_files = randomize_files(files)
     for filename in randomized_files:
         ids = id_reg_exp.findall(filename)
-        if ids is None:
+        if not ids:
             # The file name does not match the pattern containing ids, so
             # there is no id.
             category_id = None
@@ -77,7 +77,7 @@ def not_all_have_id(files):
     id_reg_exp = re.compile(FILE_PATTERN)
     for file in files:
         ids = id_reg_exp.findall(file)
-        if ids is None:
+        if not ids:
             return True
     return False
 


### PR DESCRIPTION
Hey guys, thanks for creating this great repo! I was very excited that I could train a Wavenet model over the weekend :)

I tried to train a network this weekend on a single large audio file, and I had to edit the code to make it work. It turns out that the findall method of Python's regex returns an empty list when there are no matches, instead of None as was assumed here (if None were returned, the "not None" in the new code would still return True).