### PR TITLE
TF 1.0.0 requires keyword arguments for the loss.

### DIFF
--- a/wavenet/model.py
+++ b/wavenet/model.py
@@ -663,8 +663,8 @@ class WaveNetModel(object):
                 prediction = tf.reshape(raw_output,
                                         [-1, self.quantization_channels])
                 loss = tf.nn.softmax_cross_entropy_with_logits(
-                    prediction,
-                    target_output)
+                    logits=prediction,
+                    labels=target_output)
                 reduced_loss = tf.reduce_mean(loss)
 
                 tf.summary.scalar('loss', reduced_loss)


### PR DESCRIPTION
There's been a long and extended discussion about this minimal change. If the keyword form is backwards compatible (the CI will tell), we should just change it. We might need more changes to make the code fully compatible with TF 1.0.0, though (the official version for this repo is still 0.12).