### PR TITLE
Add tensorflow to the requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Code is tested on TensorFlow version 0.12.1 for Python 2.7 and Python 3.5.
 
 In addition, [librosa](https://github.com/librosa/librosa) must be installed for reading and writing audio.
 
-To install the required python packages (except TensorFlow), run
+To install the required python packages, run
 ```bash
 pip install -r requirements.txt
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 librosa>=0.4.3
+tensorflow>=0.12


### PR DESCRIPTION
Will hopefully prevent issues like #238. Future pull requests should use the 1.0.0 API, when a breaking change is introduced we can update this.