### PR TITLE
Fix train and generate directories getting created

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -136,6 +136,8 @@ def main():
     args = get_arguments()
     started_datestring = "{0:%Y-%m-%dT%H-%M-%S}".format(datetime.now())
     logdir = os.path.join(args.logdir, 'generate', started_datestring)
+    if not os.path.exists(logdir):
+        os.makedirs(logdir)
     with open(args.wavenet_params, 'r') as config_file:
         wavenet_params = json.load(config_file)
 

--- a/train.py
+++ b/train.py
@@ -112,9 +112,6 @@ def save(saver, sess, logdir, step):
     print('Storing checkpoint to {} ...'.format(logdir), end="")
     sys.stdout.flush()
 
-    if not os.path.exists(logdir):
-        os.makedirs(logdir)
-
     saver.save(sess, checkpoint_path, global_step=step)
     print(' Done.')
 
@@ -171,6 +168,8 @@ def validate_directories(args):
     if logdir is None:
         logdir = get_default_logdir(logdir_root)
         print('Using default logdir: {}'.format(logdir))
+    if not os.path.exists(logdir):
+        os.makedirs(logdir)
 
     restore_from = args.restore_from
     if restore_from is None:


### PR DESCRIPTION
This addresses issue https://github.com/ibab/tensorflow-wavenet/issues/364

train.py was attempting to write to the 'train' directory and throwing a `NotFoundError` here: https://github.com/ibab/tensorflow-wavenet/blob/master/train.py#L274 which could happen before the `makedirs()` line in the save function was called.

generate.py did not have a call to `makedirs()` and so it was possible to get a `NotFoundError` here: https://github.com/ibab/tensorflow-wavenet/blob/master/generate.py#L263