### PR TITLE
Adding GPU automatic mixed precision training

### DIFF
--- a/train.py
+++ b/train.py
@@ -103,6 +103,8 @@ def get_arguments():
     parser.add_argument('--max_checkpoints', type=int, default=MAX_TO_KEEP,
                         help='Maximum amount of checkpoints that will be kept alive. Default: '
                              + str(MAX_TO_KEEP) + '.')
+    parser.add_argument('--automatic_mixed_precision', type=_str_to_bool, default=False,
+                        help='Using automatic mixed precision training')
     return parser.parse_args()
 
 
@@ -256,6 +258,8 @@ def main():
     optimizer = optimizer_factory[args.optimizer](
                     learning_rate=args.learning_rate,
                     momentum=args.momentum)
+    if args.auto_mixed_precision:
+        optimizer = tf.train.experimental.enable_mixed_precision_graph_rewrite(optimizer)
     trainable = tf.trainable_variables()
     optim = optimizer.minimize(loss, var_list=trainable)
 

--- a/train.py
+++ b/train.py
@@ -258,7 +258,7 @@ def main():
     optimizer = optimizer_factory[args.optimizer](
                     learning_rate=args.learning_rate,
                     momentum=args.momentum)
-    if args.auto_mixed_precision:
+    if args.automatic_mixed_precision:
         optimizer = tf.train.experimental.enable_mixed_precision_graph_rewrite(optimizer)
     trainable = tf.trainable_variables()
     optim = optimizer.minimize(loss, var_list=trainable)


### PR DESCRIPTION
Automatic Mixed Precision training on GPU for TensorFlow has been recently introduced:

https://medium.com/tensorflow/automatic-mixed-precision-in-tensorflow-for-faster-ai-training-on-nvidia-gpus-6033234b2540

Automatic mixed precision training makes use of both FP32 and FP16 precisions where appropriate. FP16 operations can leverage the Tensor cores on NVIDIA GPUs (Volta, Turing or newer architectures) for improved throughput. Mixed precision training also often allows larger batch sizes.

This PR adds GPU automatic mixed precision training to `tensorflow-wavenet` via passing the flags value `--auto_mixed_precision=True`.

```
python train.py --data_dir=/path/to/data/ --auto_mixed_precision=True
```

To learn more about mixed precision and how it works:

   [Overview of Automatic Mixed Precision for Deep Learning](https://developer.nvidia.com/automatic-mixed-precision)
    [NVIDIA Mixed Precision Training Documentation](https://docs.nvidia.com/deeplearning/sdk/mixed-precision-training/index.html)
    [NVIDIA Deep Learning Performance Guide](https://docs.nvidia.com/deeplearning/sdk/dl-performance-guide/index.html)