### PR TITLE
Fix generate.py to write summary_out properly

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -264,7 +264,7 @@ def main():
     tf.summary.audio('generated', decode, wavenet_params['sample_rate'])
     summaries = tf.summary.merge_all()
     summary_out = sess.run(summaries,
-                           feed_dict={samples: np.reshape(waveform, [-1, 1])})
+                           feed_dict={samples: np.reshape(waveform, [1, -1])})
     writer.add_summary(summary_out)
 
     # Save the result as a wav file.


### PR DESCRIPTION
Hello,

I am trying to generate audio with this model.

Giving `wav_out_path` properly, the output seems to be generated as intended. However, when I run a tensorboard server with logdir/ files, the summary file does not show up properly.
I looked up the issue tab on this repo. As mentioned in several other issues like #391, #338, #262, and #232, I couldn't see generated output. My case was the same.

By changing the shape inside `summary_out(...)` from `[-1,1]` to `[1,-1]` solved this problem.