### PR TITLE
Fix 'Travis CI' build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
       - python: 3.5
 before_install:
    - sudo apt-get update -y
-   - sudo apt-get install -y --no-install-recommends --fix-missing ca-certificates g++ libsndfile1 llvm-7 make wget
+   - sudo apt-get install -y --no-install-recommends --fix-missing ca-certificates g++ libsndfile1 llvm-7-dev make wget
 install:
    - source ci/install.sh
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ matrix:
       - python: 2.7
       - python: 3.5
 before_install:
-   - apt-get update -y
-   - apt-get install -y --no-install-recommends --fix-missing \
+   - sudo apt-get update -y
+   - sudo apt-get install -y --no-install-recommends --fix-missing \
      ca-certificates \
      g++ \
      libsndfile1 \

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,7 @@ matrix:
       - python: 3.5
 before_install:
    - sudo apt-get update -y
-   - sudo apt-get install -y --no-install-recommends --fix-missing \
-     ca-certificates \
-     g++ \
-     libsndfile1 \
-     llvm-7 \
-     make \
-     wget
+   - sudo apt-get install -y --no-install-recommends --fix-missing ca-certificates g++ libsndfile1 llvm-7 make wget
 install:
    - source ci/install.sh
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,22 @@
 language: python
 sudo: required
-dist: trusty
+dist: bionic
 matrix:
     include:
-        - python: 2.7
-        - python: 3.5
+      - python: 2.7
+      - python: 3.5
+before_install:
+   - apt-get update -y
+   - apt-get install -y --no-install-recommends --fix-missing \
+     ca-certificates \
+     g++ \
+     libsndfile1 \
+     llvm-7 \
+     make \
+     wget
 install:
-    - source ci/install.sh
+   - source ci/install.sh
 script:
-    - bash ci/test.sh
+   - bash ci/test.sh
 notifications:
-    email: false
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ sudo: required
 dist: bionic
 matrix:
     include:
-      - python: 2.7
       - python: 3.5
+      - python: 3.6
+      - python: 3.7
 before_install:
    - sudo apt-get update -y
    - sudo apt-get install -y --no-install-recommends --fix-missing ca-certificates g++ libsndfile1 llvm-7-dev make wget

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ In this repository, the network implementation can be found in <a href="./wavene
 ## Requirements
 
 TensorFlow needs to be installed before running the training script.
-Code is tested on TensorFlow version 1.0.1 for Python 2.7 and Python 3.5.
+Code is tested on TensorFlow version 1.15.2 for Python 3.5, 3.6 and 3.7.
 
 In addition, [librosa](https://github.com/librosa/librosa) must be installed for reading and writing audio.
 

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,11 +1,17 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-bash miniconda.sh -b -p $HOME/miniconda
-export PATH="$HOME/miniconda/bin:$PATH"
+wget --no-check-certificate \
+    https://repo.anaconda.com/miniconda/Miniconda2-4.7.12.1-Linux-x86_64.sh -O miniconda.sh
+
+chmod +x miniconda.sh && ./miniconda.sh -b -p ${HOME}/miniconda
+
+export PATH="${HOME}/miniconda/bin:/usr/lib/llvm-7/bin:${PATH}"
+
 conda config --set always_yes yes --set changeps1 no
-conda update -q conda
 
-conda create -q -n test python=$TRAVIS_PYTHON_VERSION numpy scipy
-source activate test
-pip install -r requirements_test.txt
+conda create -q -n test${TRAVIS_PYTHON_VERSION} python=${TRAVIS_PYTHON_VERSION}
+source activate test${TRAVIS_PYTHON_VERSION}
+
+python -m pip install pip==19.3.1
+
+python -m pip install -r requirements_test.txt

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,3 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
 pep8 **/*.py && \
 nosetests -s --nologcapture test

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 librosa>=0.5
-llvmlite<=0.32.0
+llvmlite>=0.32.0
 tensorflow<=1.15.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 librosa>=0.5
-tensorflow>=1.0.0
+llvmlite<=0.32.0
+tensorflow<=1.15.2


### PR DESCRIPTION
This PR fixes `Travis CI` builds that have been failing for a long time (3+ years).
Also `Python 2.7` has been EOL'ed since Jan. 2020 and it should no longer be used.

Here is the `Travis CI` job: https://travis-ci.org/github/ibab/tensorflow-wavenet/builds/732659859